### PR TITLE
feat: add basic form validation for client

### DIFF
--- a/client/src/pages/onboarding/cloud-provider.tsx
+++ b/client/src/pages/onboarding/cloud-provider.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { useRouter } from 'next/router';
 import { useFormik } from 'formik';
-import * as Yup from 'yup';
+import * as yup from 'yup';
 import { useSaveDigitalOceanAccessTokenMutation } from '../../generated/graphql';
 import { OnboardingLayout } from '../../layouts/OnboardingLayout';
 import withApollo from '../../lib/withApollo';
@@ -27,11 +27,12 @@ const CloudProvider = () => {
   const [
     saveDigitalOceanAccessTokenMutation,
   ] = useSaveDigitalOceanAccessTokenMutation();
-  const digitalOceanAccessTokenSchema = Yup.object().shape({
-    token: Yup.string()
+  const digitalOceanAccessTokenSchema = yup.object().shape({
+    token: yup
+      .string()
       .trim()
-      .min(64, 'Token too short, it should be exactly 64 chars long')
-      .max(64, 'Token too long, it should be exactly 64 chars long')
+      .min(64, 'Token too short, it should be exactly 64 characters long')
+      .max(64, 'Token too long, it should be exactly 64 characters long')
       .matches(
         digitalOceanAccessTokenRegExp,
         'Whoops, invalid token format. Try entering it again'

--- a/client/src/pages/onboarding/create-server.tsx
+++ b/client/src/pages/onboarding/create-server.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { useRouter } from 'next/router';
 import { useFormik } from 'formik';
 import { ArrowRight } from 'react-feather';
-
+import * as yup from 'yup';
 import { useCreateDigitalOceanServerMutation } from '../../generated/graphql';
 import { OnboardingLayout } from '../../layouts/OnboardingLayout';
 import { Headline } from '../../ui/components/Typography/components/Headline';
@@ -29,8 +29,11 @@ const CreateServer = () => {
     initialValues: {
       name: '',
     },
+    validationSchema: yup.object({
+      name: yup.string().trim().required('Server name is required'),
+    }),
+
     onSubmit: async (values) => {
-      // TODO validation name is required
       try {
         const data = await createDigitalOceanServerMutation({
           variables: { serverName: values.name },
@@ -60,6 +63,7 @@ const CreateServer = () => {
           label="Enter a name for your new server"
           value={formik.values.name}
           onChange={formik.handleChange}
+          error={formik.touched && formik.errors.name}
         />
         <Flex justifyContent="flex-end">
           <Button type="submit" background="primary" endIcon={<ArrowRight />}>

--- a/client/src/pages/onboarding/create-server.tsx
+++ b/client/src/pages/onboarding/create-server.tsx
@@ -5,19 +5,9 @@ import { ArrowRight } from 'react-feather';
 import * as yup from 'yup';
 import { useCreateDigitalOceanServerMutation } from '../../generated/graphql';
 import { OnboardingLayout } from '../../layouts/OnboardingLayout';
-import { Headline } from '../../ui/components/Typography/components/Headline';
-import { Paragraph } from '../../ui/components/Typography/components/Paragraph';
+
 import withApollo from '../../lib/withApollo';
-import {
-  TextField,
-  Button,
-  styled,
-  Flex,
-  Typography,
-  Box,
-  BoxButton,
-  Grid,
-} from '../../ui';
+import { TextField, Button, styled, Flex } from '../../ui';
 import { Protected } from '../../modules/auth/Protected';
 
 const CreateServer = () => {

--- a/client/src/ui/components/TextField/components/TextField.tsx
+++ b/client/src/ui/components/TextField/components/TextField.tsx
@@ -7,6 +7,7 @@ export interface TextFieldProps {
   id?: string;
   name?: string;
   value?: string;
+  error?: string;
   onChange?(eventOrPath: string | ChangeEvent<any>): void;
   label: string;
 }
@@ -16,6 +17,7 @@ export const TextField: React.FC<TextFieldProps> = ({ label, ...props }) => {
     <Root>
       <Label>{label}</Label>
       <Input {...props} />
+      {props.error && <HelperText>{props.error}</HelperText>}
     </Root>
   );
 };
@@ -27,6 +29,10 @@ const Root = styled.div`
 
 const Label = styled(Typography.Label)`
   margin-bottom: 8px;
+`;
+
+const HelperText = styled(Typography.Label)`
+  color: red;
 `;
 
 const Input = styled.input`

--- a/client/src/utils/index.ts
+++ b/client/src/utils/index.ts
@@ -12,3 +12,5 @@ export const serverTypeReadableName = (type: ServerTypes) => {
       return type;
   }
 };
+// Digital ocean token format = exactly 64 chars, lowercase letters & numbers
+export const digitalOceanAccessTokenRegExp = /^[a-z0-9]{64}/;

--- a/server/src/graphql/mutations/createDigitalOceanServer.ts
+++ b/server/src/graphql/mutations/createDigitalOceanServer.ts
@@ -1,8 +1,13 @@
 import fetch from 'node-fetch';
-import { MutationResolvers } from '../../generated/graphql';
-import { prisma } from './../../prisma';
+import * as yup from 'yup';
 import Crypto from 'crypto';
 import sshpk from 'sshpk';
+import { MutationResolvers } from '../../generated/graphql';
+import { prisma } from './../../prisma';
+
+const createDigitalOceanServerSchema = yup.object({
+  serverName: yup.string().required(),
+});
 
 export const createDigitalOceanServer: MutationResolvers['createDigitalOceanServer'] = async (
   _,
@@ -20,6 +25,9 @@ export const createDigitalOceanServer: MutationResolvers['createDigitalOceanServ
   if (!currentUser.digitaloceanAccessToken) {
     throw new Error('Digitalocean token required');
   }
+
+  // We make sure the name is valid to avoid security risks
+  createDigitalOceanServerSchema.validateSync({ serverName });
 
   // check to see whether can follow the action
   // ACTION STATE

--- a/server/src/graphql/mutations/saveDigitalOceanAccessToken.ts
+++ b/server/src/graphql/mutations/saveDigitalOceanAccessToken.ts
@@ -1,6 +1,16 @@
 import fetch from 'node-fetch';
+import * as yup from 'yup';
+import { digitalOceanAccessTokenRegExp } from './../utils';
 import { MutationResolvers } from '../../generated/graphql';
 import { prisma } from '../../prisma';
+
+// TODO unit test this schema
+const saveDigitalOceanTokenSchema = yup.object({
+  digitalOceanAccessToken: yup
+    .string()
+    .required()
+    .matches(digitalOceanAccessTokenRegExp),
+});
 
 export const saveDigitalOceanAccessToken: MutationResolvers['saveDigitalOceanAccessToken'] = async (
   _,
@@ -10,6 +20,9 @@ export const saveDigitalOceanAccessToken: MutationResolvers['saveDigitalOceanAcc
   if (!userId) {
     throw new Error('Unauthorized');
   }
+
+  // We make sure the token is valid to avoid security risks
+  saveDigitalOceanTokenSchema.validateSync({ digitalOceanAccessToken });
 
   try {
     const resData = await fetch('https://api.digitalocean.com/v2/account', {

--- a/server/src/graphql/utils.ts
+++ b/server/src/graphql/utils.ts
@@ -1,0 +1,2 @@
+// Digital ocean token format = exactly 64 chars, lowercase letters & numbers
+export const digitalOceanAccessTokenRegExp = /^[a-z0-9]{64}/;


### PR DESCRIPTION
- Setup yup schema for digital ocean access token and server name
- Min and max checks were added to give more feedback if token has not pasted properly or something extra entered
- Added helper text in UI component
- Nice addition to this would be disabled buttons, perhaps todo for @bartaxyz ?

<img width="943" alt="Screenshot 2020-05-03 at 10 34 38" src="https://user-images.githubusercontent.com/25903618/80909595-b77fc100-8d29-11ea-8fb0-eb03001fa437.png">



