### PR TITLE
fix: critical mistake in the README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ![Dashboard](/images/Dashboard.png)
 
-Ledokku is a beautiful UI powered by [dokku]("dokku")
+Ledokku is a beautiful UI powered by [dokku]("http://dokku.viewdocs.io/dokku/")
 
 With us you will be able to deploy apps written in:
 **node.js, php, ruby and many more**.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ![Dashboard](/images/Dashboard.png)
 
-Ledokku is a beautiful UI powered by [dokku]("http://dokku.viewdocs.io/dokku/")
+Ledokku is a beautiful UI powered by [dokku](http://dokku.viewdocs.io/dokku/)
 
 With us you will be able to deploy apps written in:
 **node.js, php, ruby and many more**.


### PR DESCRIPTION
Hello,

just passing by and found a little error in the README file, the link was redirecting to a 404 page and I assumed that you wanted to refer to http://dokku.viewdocs.io/dokku/ ... Feel free to cestinate this PR if it's not the expected behaviour.

cheers ✌️