### PR TITLE
feat(client): add app settings view

### DIFF
--- a/client/src/generated/graphql.tsx
+++ b/client/src/generated/graphql.tsx
@@ -229,6 +229,19 @@ export type CreateDatabaseMutation = (
   ) }
 );
 
+export type DestroyAppMutationVariables = {
+  input: DestroyAppInput;
+};
+
+
+export type DestroyAppMutation = (
+  { __typename?: 'Mutation' }
+  & { destroyApp: (
+    { __typename?: 'DestroyAppResult' }
+    & Pick<DestroyAppResult, 'result'>
+  ) }
+);
+
 export type LoginWithGithubMutationVariables = {
   code: Scalars['String'];
 };
@@ -385,6 +398,38 @@ export function useCreateDatabaseMutation(baseOptions?: ApolloReactHooks.Mutatio
 export type CreateDatabaseMutationHookResult = ReturnType<typeof useCreateDatabaseMutation>;
 export type CreateDatabaseMutationResult = ApolloReactCommon.MutationResult<CreateDatabaseMutation>;
 export type CreateDatabaseMutationOptions = ApolloReactCommon.BaseMutationOptions<CreateDatabaseMutation, CreateDatabaseMutationVariables>;
+export const DestroyAppDocument = gql`
+    mutation destroyApp($input: DestroyAppInput!) {
+  destroyApp(input: $input) {
+    result
+  }
+}
+    `;
+export type DestroyAppMutationFn = ApolloReactCommon.MutationFunction<DestroyAppMutation, DestroyAppMutationVariables>;
+
+/**
+ * __useDestroyAppMutation__
+ *
+ * To run a mutation, you first call `useDestroyAppMutation` within a React component and pass it any options that fit your needs.
+ * When your component renders, `useDestroyAppMutation` returns a tuple that includes:
+ * - A mutate function that you can call at any time to execute the mutation
+ * - An object with fields that represent the current status of the mutation's execution
+ *
+ * @param baseOptions options that will be passed into the mutation, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options-2;
+ *
+ * @example
+ * const [destroyAppMutation, { data, loading, error }] = useDestroyAppMutation({
+ *   variables: {
+ *      input: // value for 'input'
+ *   },
+ * });
+ */
+export function useDestroyAppMutation(baseOptions?: ApolloReactHooks.MutationHookOptions<DestroyAppMutation, DestroyAppMutationVariables>) {
+        return ApolloReactHooks.useMutation<DestroyAppMutation, DestroyAppMutationVariables>(DestroyAppDocument, baseOptions);
+      }
+export type DestroyAppMutationHookResult = ReturnType<typeof useDestroyAppMutation>;
+export type DestroyAppMutationResult = ApolloReactCommon.MutationResult<DestroyAppMutation>;
+export type DestroyAppMutationOptions = ApolloReactCommon.BaseMutationOptions<DestroyAppMutation, DestroyAppMutationVariables>;
 export const LoginWithGithubDocument = gql`
     mutation loginWithGithub($code: String!) {
   loginWithGithub(code: $code) {

--- a/client/src/graphql/mutations/destroyApp.graphql
+++ b/client/src/graphql/mutations/destroyApp.graphql
@@ -1,0 +1,5 @@
+mutation destroyApp($input: DestroyAppInput!) {
+  destroyApp(input: $input) {
+    result
+  }
+}

--- a/client/src/pages/app/[appId]/env.tsx
+++ b/client/src/pages/app/[appId]/env.tsx
@@ -163,7 +163,12 @@ const Env = () => {
           envVarData.envVars.envVars &&
           envVarData.envVars.envVars.map((envVar) => {
             return (
-              <EnvForm name={envVar.key} value={envVar.value} appId={appId} />
+              <EnvForm
+                key={envVar.key}
+                name={envVar.key}
+                value={envVar.value}
+                appId={appId}
+              />
             );
           })}
       </div>

--- a/client/src/pages/app/[appId]/settings.tsx
+++ b/client/src/pages/app/[appId]/settings.tsx
@@ -1,0 +1,157 @@
+import React from 'react';
+import { useRouter } from 'next/router';
+import * as yup from 'yup';
+import withApollo from '../../../lib/withApollo';
+
+import { Protected } from '../../../modules/auth/Protected';
+import { Header } from '../../../modules/layout/Header';
+import {
+  useAppByIdQuery,
+  useDestroyAppMutation,
+} from '../../../generated/graphql';
+import Link from 'next/link';
+import { useFormik } from 'formik';
+
+const Settings = () => {
+  const router = useRouter();
+  // // On first render appId will be undefined, the value is set after and a rerender is triggered.
+  const { appId } = router.query as { appId?: string };
+  const [destroyAppMutation] = useDestroyAppMutation();
+
+  const { data, loading, error } = useAppByIdQuery({
+    variables: {
+      appId,
+    },
+    ssr: false,
+    skip: !appId,
+  });
+
+  if (!data) {
+    return null;
+  }
+
+  // // TODO display error
+
+  if (loading) {
+    // TODO nice loading
+    return <p>Loading...</p>;
+  }
+
+  const { app } = data;
+
+  if (!app) {
+    // TODO nice 404
+    return <p>App not found.</p>;
+  }
+
+  const DeleteAppNameSchema = yup.object().shape({
+    appName: yup
+      .string()
+      .required('Required')
+      .test(
+        'Equals app name',
+        'Must match app name',
+        (val) => val === data.app.name
+      ),
+  });
+
+  const formik = useFormik<{ appName: string }>({
+    initialValues: {
+      appName: '',
+    },
+
+    validateOnChange: true,
+    validationSchema: DeleteAppNameSchema,
+
+    onSubmit: async (values) => {
+      console.log('triggered');
+      try {
+        const data = await destroyAppMutation({
+          variables: {
+            input: { appId },
+          },
+          refetchQueries: [],
+        });
+
+        router.push('/dashboard');
+      } catch (error) {
+        // TODO catch errors
+        console.log(error);
+        alert(error);
+      }
+    },
+  });
+
+  return (
+    <div>
+      <Header />
+      <div className="max-w-5xl mx-auto px-4 sm:px-6 lg:px-8">
+        <nav className="flex space-x-5 text-sm leading-5 border-b border-gray-200">
+          <Link href="/app/[appId]" as={`/app/${app.id}`} passHref>
+            <a className="text-gray-500 hover:text-black py-3 px-0.5 transition-colors ease-in-out duration-150">
+              App
+            </a>
+          </Link>
+          <Link href="/app/[appId]/env" as={`/app/${app.id}/env`} passHref>
+            <a className="text-gray-500 hover:text-black py-3 px-0.5 transition-colors ease-in-out duration-15">
+              Env setup
+            </a>
+          </Link>
+          <Link
+            href="/app/[appId]/settings"
+            as={`/app/${app.id}/settings`}
+            passHref
+          >
+            <a className="-mb-px border-b border-black text-black py-3 px-0.5">
+              Settings
+            </a>
+          </Link>
+          <Link href="/dashboard" passHref>
+            <a className="text-gray-500 hover:text-black py-3 px-0.5 transition-colors ease-in-out duration-15">
+              Return to dashboard
+            </a>
+          </Link>
+        </nav>
+      </div>
+      <div className="max-w-5xl mx-auto px-4 sm:px-6 lg:px-8">
+        <div className="grid sm:grid-cols-1 md:grid-cols-1 lg:grid-cols-1 xl:grid-cols-1 gap-4 mt-10">
+          <h1 className="text-lg font-bold py-5">App settings</h1>
+
+          <h2 className="text-gray-400">
+            To delete the app type the name of the app below and click Delete
+          </h2>
+          <form onSubmit={formik.handleSubmit} className="mt-2">
+            <div className="mt-4">
+              <input
+                className="block w-full max-w-xs bg-white border border-grey rounded py-3 px-3 text-sm leading-tight transition duration-200 focus:outline-none focus:border-black"
+                id="appNme"
+                name="appName"
+                value={formik.values.appName}
+                onChange={formik.handleChange}
+              />
+              {!!formik.errors && (
+                <p className="text-red-500 text-sm font-semibold">
+                  {formik.errors.appName}
+                </p>
+              )}
+
+              <button
+                disabled={!!formik.errors && formik.isSubmitting}
+                type="submit"
+                className="inline mt-6 py-2 px-10 bg-red-500 hover:bg-blue text-white  font-bold hover:text-white border hover:border-transparent rounded-lg "
+              >
+                Delete
+              </button>
+            </div>
+          </form>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default withApollo(() => (
+  <Protected>
+    <Settings />
+  </Protected>
+));

--- a/client/src/pages/app/[appId]/settings.tsx
+++ b/client/src/pages/app/[appId]/settings.tsx
@@ -8,6 +8,7 @@ import { Header } from '../../../modules/layout/Header';
 import {
   useAppByIdQuery,
   useDestroyAppMutation,
+  DashboardDocument,
 } from '../../../generated/graphql';
 import Link from 'next/link';
 import { useFormik } from 'formik';
@@ -64,13 +65,16 @@ const Settings = () => {
     validationSchema: DeleteAppNameSchema,
 
     onSubmit: async (values) => {
-      console.log('triggered');
       try {
         const data = await destroyAppMutation({
           variables: {
             input: { appId },
           },
-          refetchQueries: [],
+          refetchQueries: [
+            {
+              query: DashboardDocument,
+            },
+          ],
         });
 
         router.push('/dashboard');
@@ -117,10 +121,12 @@ const Settings = () => {
         <div className="grid sm:grid-cols-1 md:grid-cols-1 lg:grid-cols-1 xl:grid-cols-1 gap-4 mt-10">
           <h1 className="text-lg font-bold py-5">App settings</h1>
 
-          <h2 className="text-gray-400">
-            To delete the app type the name of the app below and click Delete
+          <h2 className="text-gray-400 w-2/6">
+            This action cannot be undone. This will permanently delete{' '}
+            {app.name} app and everything related to it. Please type{' '}
+            <b>{app.name}</b> to confirm deletion.
           </h2>
-          <form onSubmit={formik.handleSubmit} className="mt-2">
+          <form onSubmit={formik.handleSubmit}>
             <div className="mt-4">
               <input
                 className="block w-full max-w-xs bg-white border border-grey rounded py-3 px-3 text-sm leading-tight transition duration-200 focus:outline-none focus:border-black"


### PR DESCRIPTION
@pradel Whoop whoop! Another view bites the dust 🎉 . 

Works as expected, one thing that could probably be fixed is adding refetchQuery when redirected to dashboard. Currently when we first get to dashboard for a short bit deleted app still appears there. 

W/o apollo hooks and `useMutation(MUTATION_NAME)` you just do refetchQueries, but how do I handle this when it's `useThisParticularMutation()`? 


<img width="1047" alt="Screenshot 2020-05-29 at 21 58 07" src="https://user-images.githubusercontent.com/25903618/83300036-8d6dd180-a1f7-11ea-9cc6-0df8047c2bce.png">
