### PR TITLE
chore(server): migrate createdAt fields from datetime to string

### DIFF
--- a/client/src/generated/graphql.tsx
+++ b/client/src/generated/graphql.tsx
@@ -20,6 +20,7 @@ export type App = {
   id: Scalars['ID'];
   name: Scalars['String'];
   githubRepoUrl: Scalars['String'];
+  createdAt: Scalars['String'];
 };
 
 export type AppBuild = {
@@ -279,7 +280,7 @@ export type AppByIdQuery = (
   { __typename?: 'Query' }
   & { app?: Maybe<(
     { __typename?: 'App' }
-    & Pick<App, 'id' | 'name' | 'githubRepoUrl'>
+    & Pick<App, 'id' | 'name' | 'githubRepoUrl' | 'createdAt'>
   )> }
 );
 
@@ -502,6 +503,7 @@ export const AppByIdDocument = gql`
     id
     name
     githubRepoUrl
+    createdAt
   }
 }
     `;

--- a/client/src/graphql/queries/app.graphql
+++ b/client/src/graphql/queries/app.graphql
@@ -3,5 +3,6 @@ query appById($appId: String!) {
     id
     name
     githubRepoUrl
+    createdAt
   }
 }

--- a/client/src/pages/app/[appId]/index.tsx
+++ b/client/src/pages/app/[appId]/index.tsx
@@ -117,7 +117,9 @@ const App = () => {
                     <td className="w-1/3 text-left py-3 px-4 font-semibold">
                       Created at
                     </td>
-                    <td className="w-1/3 text-left py-3 px-4">17th of April</td>
+                    <td className="w-1/3 text-left py-3 px-4">
+                      {app.createdAt}
+                    </td>
                   </tr>
                 </tbody>
               </table>

--- a/server/prisma/migrations/20200530212153-datetime-changed-to-string/README.md
+++ b/server/prisma/migrations/20200530212153-datetime-changed-to-string/README.md
@@ -1,0 +1,84 @@
+# Migration `20200530212153-datetime-changed-to-string`
+
+This migration has been generated at 5/30/2020, 9:21:53 PM.
+You can check out the [state of the schema](./schema.prisma) after the migration.
+
+## Database Steps
+
+```sql
+ALTER TABLE "public"."Database" DROP COLUMN "createdAt",
+ADD COLUMN "createdAt" timestamp(3)  NOT NULL DEFAULT CURRENT_TIMESTAMP,
+DROP COLUMN "updatedAt",
+ADD COLUMN "updatedAt" timestamp(3)  NOT NULL DEFAULT CURRENT_TIMESTAMP;
+```
+
+## Changes
+
+```diff
+diff --git schema.prisma schema.prisma
+migration 20200510152117-init..20200530212153-datetime-changed-to-string
+--- datamodel.dml
++++ datamodel.dml
+@@ -1,31 +1,31 @@
+ datasource db {
+   provider = "postgresql"
+-  url = "***"
++  url      = env("DATABASE_URL")
+ }
+ generator client {
+   provider = "prisma-client-js"
+ }
+ model User {
+-  id                      String     @default(uuid()) @id
+-  createdAt               DateTime   @default(now())
+-  updatedAt               DateTime   @default(now())
+-  username                String     @unique
+-  avatarUrl               String
+-  email                   String
+-  githubId                String     @unique
+-  githubAccessToken       String
+-  App                     App[]
+-  Database                Database[]
+-  AppBuild                AppBuild[]
++  id                String     @default(uuid()) @id
++  createdAt         DateTime   @default(now())
++  updatedAt         DateTime   @default(now())
++  username          String     @unique
++  avatarUrl         String
++  email             String
++  githubId          String     @unique
++  githubAccessToken String
++  App               App[]
++  Database          Database[]
++  AppBuild          AppBuild[]
+ }
+ model App {
+   id            String     @default(uuid()) @id
+-  createdAt     DateTime   @default(now())
+-  updatedAt     DateTime   @default(now())
++  createdAt     String
++  updatedAt     String
+   name          String
+   githubRepoUrl String
+   githubId      String
+   user          User       @relation(fields: [userId], references: [id])
+@@ -34,10 +34,10 @@
+ }
+ model AppBuild {
+   id        String         @default(uuid()) @id
+-  createdAt DateTime       @default(now())
+-  updatedAt DateTime       @default(now())
++  createdAt String
++  updatedAt String
+   status    AppBuildStatus
+   app       App            @relation(fields: [appId], references: [id])
+   appId     String
+   user      User           @relation(fields: [userId], references: [id])
+@@ -65,5 +65,5 @@
+   REDIS
+   POSTGRESQL
+   MONGODB
+   MYSQL
+-}
++}
+```

--- a/server/prisma/migrations/20200530212153-datetime-changed-to-string/schema.prisma
+++ b/server/prisma/migrations/20200530212153-datetime-changed-to-string/schema.prisma
@@ -1,6 +1,6 @@
 datasource db {
   provider = "postgresql"
-  url      = env("DATABASE_URL")
+  url = "***"
 }
 
 generator client {

--- a/server/prisma/migrations/20200530212153-datetime-changed-to-string/steps.json
+++ b/server/prisma/migrations/20200530212153-datetime-changed-to-string/steps.json
@@ -1,0 +1,73 @@
+{
+  "version": "0.3.14-fixed",
+  "steps": [
+    {
+      "tag": "UpdateField",
+      "model": "App",
+      "field": "createdAt",
+      "type": "String"
+    },
+    {
+      "tag": "DeleteDirective",
+      "location": {
+        "path": {
+          "tag": "Field",
+          "model": "App",
+          "field": "createdAt"
+        },
+        "directive": "default"
+      }
+    },
+    {
+      "tag": "UpdateField",
+      "model": "App",
+      "field": "updatedAt",
+      "type": "String"
+    },
+    {
+      "tag": "DeleteDirective",
+      "location": {
+        "path": {
+          "tag": "Field",
+          "model": "App",
+          "field": "updatedAt"
+        },
+        "directive": "default"
+      }
+    },
+    {
+      "tag": "UpdateField",
+      "model": "AppBuild",
+      "field": "createdAt",
+      "type": "String"
+    },
+    {
+      "tag": "DeleteDirective",
+      "location": {
+        "path": {
+          "tag": "Field",
+          "model": "AppBuild",
+          "field": "createdAt"
+        },
+        "directive": "default"
+      }
+    },
+    {
+      "tag": "UpdateField",
+      "model": "AppBuild",
+      "field": "updatedAt",
+      "type": "String"
+    },
+    {
+      "tag": "DeleteDirective",
+      "location": {
+        "path": {
+          "tag": "Field",
+          "model": "AppBuild",
+          "field": "updatedAt"
+        },
+        "directive": "default"
+      }
+    }
+  ]
+}

--- a/server/prisma/migrations/migrate.lock
+++ b/server/prisma/migrations/migrate.lock
@@ -4,3 +4,4 @@
 # Read more about conflict resolution here: TODO
 
 20200510152117-init
+20200530212153-datetime-changed-to-string

--- a/server/src/generated/graphql.ts
+++ b/server/src/generated/graphql.ts
@@ -19,6 +19,7 @@ export type App = {
   id: Scalars['ID'];
   name: Scalars['String'];
   githubRepoUrl: Scalars['String'];
+  createdAt: Scalars['String'];
 };
 
 export type AppBuild = {
@@ -332,6 +333,7 @@ export type AppResolvers<ContextType = any, ParentType extends ResolversParentTy
   id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>,
   name?: Resolver<ResolversTypes['String'], ParentType, ContextType>,
   githubRepoUrl?: Resolver<ResolversTypes['String'], ParentType, ContextType>,
+  createdAt?: Resolver<ResolversTypes['String'], ParentType, ContextType>,
   __isTypeOf?: isTypeOfResolverFn<ParentType>,
 };
 

--- a/server/src/graphql/mutations/createApp.ts
+++ b/server/src/graphql/mutations/createApp.ts
@@ -33,6 +33,8 @@ export const createApp: MutationResolvers['createApp'] = async (
           id: userId,
         },
       },
+      createdAt: new Date().toString(),
+      updatedAt: new Date().toString(),
     },
   });
 
@@ -49,6 +51,8 @@ export const createApp: MutationResolvers['createApp'] = async (
           id: app.id,
         },
       },
+      createdAt: new Date().toString(),
+      updatedAt: new Date().toString(),
     },
   });
 


### PR DESCRIPTION
Now we see real app creation date instead of hardcoded one.

@pradel currently I created migration only for app and appBuild. 

I guess couple of questions regarding this : 
- What would be the benefits of leaving DateTime in prisma schema vs moving it to String? 
- Should I convert all models to String for now or the plan is to sometime soon create custom graphql scalar DateTime?

This is the last PR today 🤣 