### PR TITLE
fix: fix server docker image prisma cli not present in production image

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -14,6 +14,7 @@
   },
   "dependencies": {
     "@octokit/rest": "18.0.5",
+    "@prisma/cli": "2.6.2",
     "@prisma/client": "2.6.2",
     "apollo-server": "2.17.0",
     "apollo-server-express": "2.17.0",
@@ -36,7 +37,6 @@
     "@graphql-codegen/cli": "1.17.8",
     "@graphql-codegen/typescript": "1.17.9",
     "@graphql-codegen/typescript-resolvers": "1.17.9",
-    "@prisma/cli": "2.6.2",
     "@types/debug": "4.1.5",
     "@types/jsonwebtoken": "8.5.0",
     "@types/node": "14.0.27",


### PR DESCRIPTION
Fix #125