### PR TITLE
feat(client): integrate react-toastify

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -41,6 +41,7 @@
     "react-router-dom": "5.2.0",
     "react-select": "3.1.0",
     "styled-components": "5.1.1",
+    "react-toastify": "6.0.8",
     "yup": "0.29.2"
   },
   "devDependencies": {
@@ -52,6 +53,7 @@
     "@tailwindcss/ui": "0.6.0",
     "@types/classnames": "2.2.10",
     "@types/jwt-decode": "2.2.1",
+    "@types/react-toastify": "4.1.0",
     "@types/node": "14.0.27",
     "@types/react": "16.9.44",
     "@types/react-dom": "16.9.8",

--- a/client/src/Router.tsx
+++ b/client/src/Router.tsx
@@ -6,6 +6,7 @@ import {
   RouteProps,
   Redirect,
 } from 'react-router-dom';
+import { ToastContainer } from 'react-toastify';
 import { useAuth } from './modules/auth/AuthContext';
 import { Home } from './pages/home';
 import { App } from './pages/app/index';
@@ -47,6 +48,7 @@ const PrivateRoute = ({ children, ...rest }: RouteProps) => {
 export const Router = () => {
   return (
     <BrowserRouter>
+      <ToastContainer position={'top-left'} />
       <Switch>
         <Route path="/" exact>
           <Home />

--- a/client/src/index.tsx
+++ b/client/src/index.tsx
@@ -14,6 +14,7 @@ import { WebSocketLink } from '@apollo/client/link/ws';
 import { setContext } from '@apollo/client/link/context';
 import { onError } from '@apollo/client/link/error';
 import './generated/index.css';
+import 'react-toastify/dist/ReactToastify.css';
 import { config } from './config';
 import { AuthProvider } from './modules/auth/AuthContext';
 import { Router } from './Router';

--- a/client/src/pages/app/env.tsx
+++ b/client/src/pages/app/env.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import { useParams } from 'react-router-dom';
+import { toast } from 'react-toastify';
 import { Header } from '../../modules/layout/Header';
 import {
   useAppByIdQuery,
@@ -37,9 +38,7 @@ export const EnvForm = ({ name, value, appId, isNewVar }: EnvFormProps) => {
         refetchQueries: [{ query: EnvVarsDocument, variables: { appId } }],
       });
     } catch (error) {
-      // TODO catch errors
-      console.log(error);
-      alert(error);
+      toast.error(error.message);
     }
   };
 
@@ -62,9 +61,7 @@ export const EnvForm = ({ name, value, appId, isNewVar }: EnvFormProps) => {
 
         // TODO give feedback about setting success
       } catch (error) {
-        // TODO catch errors
-        console.log(error);
-        alert(error);
+        toast.error(error.message);
       }
     },
   });

--- a/client/src/pages/app/index.tsx
+++ b/client/src/pages/app/index.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import Select from 'react-select';
+import { toast } from 'react-toastify';
 import { Header } from '../../modules/layout/Header';
 import {
   useAppByIdQuery,
@@ -127,7 +128,7 @@ export const App = () => {
       setIsTerminalVisible(true);
       setUnlinkLoading(true);
     } catch (e) {
-      //TODO - REACT TOSTIFY
+      toast.error(e.message);
     }
   };
 
@@ -148,7 +149,7 @@ export const App = () => {
       setIsTerminalVisible(true);
       setLinkLoading(true);
     } catch (e) {
-      //TODO - REACT TOSTIFY
+      toast.error(e.message);
     }
   };
 

--- a/client/src/pages/app/settings.tsx
+++ b/client/src/pages/app/settings.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import * as yup from 'yup';
 import { useHistory, useParams } from 'react-router-dom';
+import { toast } from 'react-toastify';
 import { Header } from '../../modules/layout/Header';
 import {
   useAppByIdQuery,
@@ -57,11 +58,10 @@ export const Settings = () => {
             },
           ],
         });
+        toast.success('App deleted successfully');
         history.push('/dashboard');
       } catch (error) {
-        // TODO catch errors
-        console.log(error);
-        alert(error);
+        toast.error(error.message);
       }
     },
   });

--- a/client/src/pages/create-app.tsx
+++ b/client/src/pages/create-app.tsx
@@ -4,6 +4,7 @@ import { useFormik } from 'formik';
 import { useCreateAppMutation, DashboardDocument } from '../generated/graphql';
 import { Header } from '../modules/layout/Header';
 import { Button } from '../ui';
+import { toast } from 'react-toastify';
 
 export const CreateApp = () => {
   const history = useHistory();
@@ -27,12 +28,11 @@ export const CreateApp = () => {
           ],
         });
         if (data?.data) {
+          toast.success('App created successfully');
           history.push(`/app/${data.data.createApp.app.id}`);
         }
       } catch (error) {
-        // TODO catch errors
-        console.log(error);
-        alert(error);
+        toast.error(error.message);
       }
     },
   });

--- a/client/src/pages/create-database.tsx
+++ b/client/src/pages/create-database.tsx
@@ -2,6 +2,7 @@ import React, { useEffect } from 'react';
 import { useHistory } from 'react-router-dom';
 import { useFormik } from 'formik';
 import { ArrowRight } from 'react-feather';
+import { toast } from 'react-toastify';
 import cx from 'classnames';
 import {
   useCreateDatabaseMutation,
@@ -80,12 +81,11 @@ export const CreateDatabase = () => {
             },
           ],
         });
+        toast.success('Database created successfully');
         // TODO redirect to database page once ready
         history.push('/dashboard');
       } catch (error) {
-        // TODO catch errors
-        console.log(error);
-        alert(error);
+        toast.error(error.message);
       }
     },
   });

--- a/client/src/pages/database/index.tsx
+++ b/client/src/pages/database/index.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from 'react';
+import { toast } from 'react-toastify';
 import { Header } from '../../modules/layout/Header';
 import {
   useDatabaseByIdQuery,
@@ -95,7 +96,7 @@ export const Database = () => {
       setIsTerminalVisible(true);
       setUnlinkLoading(true);
     } catch (e) {
-      //TODO - REACT TOSTIFY
+      toast.error(e.message);
     }
   };
 
@@ -135,7 +136,7 @@ export const Database = () => {
       setLinkLoading(true);
       // TODO - REACT - TOASTIFY
     } catch (e) {
-      //TODO - REACT TOASTIFY
+      toast.error(e.message);
     }
   };
 

--- a/client/src/pages/database/settings.tsx
+++ b/client/src/pages/database/settings.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import * as yup from 'yup';
 import { useParams, useHistory } from 'react-router-dom';
 import { useFormik } from 'formik';
+import { toast } from 'react-toastify';
 import { Header } from '../../modules/layout/Header';
 import {
   useDatabaseByIdQuery,
@@ -80,11 +81,10 @@ export const Settings = () => {
             },
           ],
         });
+        toast.success('Database deleted successfully');
         history.push('/dashboard');
       } catch (error) {
-        // TODO catch errors
-        console.log(error);
-        alert(error);
+        toast.error(error.message);
       }
     },
   });

--- a/yarn.lock
+++ b/yarn.lock
@@ -3634,6 +3634,13 @@
     "@types/history" "*"
     "@types/react" "*"
 
+"@types/react-toastify@4.1.0":
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/@types/react-toastify/-/react-toastify-4.1.0.tgz#604e712855dd677916d5c66af595d3b590f5d95d"
+  integrity sha512-u7Ie/7LHBsPVz/iJxi/WlRDS7Gh9csCJACTDXx+pSLuZCm94xpkwzhM3jV1L5ZxP/in0Gp2tFbJ91VrSGr1gyQ==
+  dependencies:
+    react-toastify "*"
+
 "@types/react-toggle@^4.0.2":
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/@types/react-toggle/-/react-toggle-4.0.2.tgz#46ffa5af1a55de5f25d0aa78ef0b557b5c8bf276"
@@ -5888,7 +5895,7 @@ class-utils@^0.3.5:
     isobject "^3.0.0"
     static-extend "^0.1.1"
 
-classnames@2.2.6, classnames@^2.2.5:
+classnames@2.2.6, classnames@^2.2.5, classnames@^2.2.6:
   version "2.2.6"
   resolved "https://registry.yarnpkg.com/classnames/-/classnames-2.2.6.tgz#43935bffdd291f326dad0a205309b38d00f650ce"
   integrity sha512-JR/iSQOSt+LQIWwrwEzJ9uk0xfN3mTVYMwt1Ir5mUcSN6pU+V4zQFFaJsclJbPuAUQH+yfWef6tm7l1quW3C8Q==
@@ -14127,6 +14134,15 @@ react-textarea-autosize@^6.1.0:
   dependencies:
     prop-types "^15.6.0"
 
+react-toastify@*, react-toastify@6.0.8:
+  version "6.0.8"
+  resolved "https://registry.yarnpkg.com/react-toastify/-/react-toastify-6.0.8.tgz#84625d81d0fd01902a7f4c6f317eb074cb3bba67"
+  integrity sha512-NSqCNwv+C4IfR+c92PFZiNyeBwOJvigrP2bcRi2f6Hg3WqcHhEHOknbSQOs9QDFuqUjmK3SOrdvScQ3z63ifXg==
+  dependencies:
+    classnames "^2.2.6"
+    prop-types "^15.7.2"
+    react-transition-group "^4.4.1"
+
 react-toggle@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/react-toggle/-/react-toggle-4.1.1.tgz#2317f67bf918ea3508a96b09dd383efd9da572af"
@@ -14134,7 +14150,7 @@ react-toggle@^4.1.1:
   dependencies:
     classnames "^2.2.5"
 
-react-transition-group@^4.3.0:
+react-transition-group@^4.3.0, react-transition-group@^4.4.1:
   version "4.4.1"
   resolved "https://registry.yarnpkg.com/react-transition-group/-/react-transition-group-4.4.1.tgz#63868f9325a38ea5ee9535d828327f85773345c9"
   integrity sha512-Djqr7OQ2aPUiYurhPalTrVy9ddmFCCzwhqQmtN+J3+3DzLO209Fdr70QrN8Z3DsglWql6iY1lDWAfpFiBtuKGw==


### PR DESCRIPTION
Closes : https://github.com/ledokku/ledokku/issues/111 

Added toast messages in multiple locations and it seems to both look and work absolutely great! ( some previews below )

Some challenging parts where it's yet to be done are operations with queues where successful mutation doesn't necessarily allow us to show "success message", but errors still will be displayed with toast messages.

Also another todo in future would be to customise error messages, but that's so far ahead that it probably doesn't even make sense to create issue now.

Error message : 
![image](https://user-images.githubusercontent.com/25903618/94997239-82b2b700-05b2-11eb-8cb4-b6bc5f5f1387.png)

Success message : 
![image](https://user-images.githubusercontent.com/25903618/94997247-89412e80-05b2-11eb-9edf-8fddb8a7b3e6.png)
