### PR TITLE
fix(server): fix max listeners exceeded warning

### DIFF
--- a/server/src/config.ts
+++ b/server/src/config.ts
@@ -86,7 +86,6 @@ export const config = {
   githubClientId: process.env.GITHUB_CLIENT_ID,
   githubClientSecret: process.env.GITHUB_CLIENT_SECRET,
   redisUrl: process.env.REDIS_URL,
-  redisClient: new Redis(process.env.REDIS_URL),
   dokkuSshHost: process.env.DOKKU_SSH_HOST,
   dokkuSshPort: process.env.DOKKU_SSH_PORT ? +process.env.DOKKU_SSH_PORT : 22,
   privateKey,

--- a/server/src/queues/synchroniseServer.ts
+++ b/server/src/queues/synchroniseServer.ts
@@ -1,5 +1,6 @@
 import { Worker, Queue } from 'bullmq';
 import createDebug from 'debug';
+import Redis from 'ioredis';
 import { config } from '../config';
 import { sshConnect } from '../lib/ssh';
 import { dokku } from '../lib/dokku';
@@ -8,13 +9,14 @@ import { dbTypeToDokkuPlugin } from '../graphql/utils';
 import { DatabaseTypes } from '../generated/graphql';
 
 const queueName = 'synchronise-server';
+const redisClient = new Redis(config.redisUrl);
 
 export const synchroniseServerQueue = new Queue(queueName, {
   defaultJobOptions: {
     // Max timeout 20 minutes
     timeout: 1.2e6,
   },
-  connection: config.redisClient,
+  connection: redisClient,
 });
 
 /**
@@ -172,7 +174,7 @@ const worker = new Worker(
     debug(`finished`);
     console.log('Finished synchronisation with Dokku');
   },
-  { connection: config.redisClient }
+  { connection: redisClient }
 );
 
 worker.on('failed', async (job, err) => {

--- a/server/src/queues/unlinkDatabase.ts
+++ b/server/src/queues/unlinkDatabase.ts
@@ -1,6 +1,7 @@
 import { dbTypeToDokkuPlugin } from './../graphql/utils';
 import { Worker, Queue } from 'bullmq';
 import createDebug from 'debug';
+import Redis from 'ioredis';
 import { pubsub } from './../index';
 import { config } from '../config';
 import { sshConnect } from '../lib/ssh';
@@ -9,6 +10,7 @@ import { prisma } from '../prisma';
 
 const queueName = 'unlink-database';
 const debug = createDebug(`queue:${queueName}`);
+const redisClient = new Redis(config.redisUrl);
 
 interface QueueArgs {
   appId: string;
@@ -20,7 +22,7 @@ export const unlinkDatabaseQueue = new Queue<QueueArgs>(queueName, {
     // Max timeout 20 minutes
     timeout: 1.2e6,
   },
-  connection: config.redisClient,
+  connection: redisClient,
 });
 
 /**
@@ -75,7 +77,7 @@ const worker = new Worker(
       `finishing unlinkDatabaseQueue for ${database.type} database ${database.name} from  ${app.name} app`
     );
   },
-  { connection: config.redisClient }
+  { connection: redisClient }
 );
 
 worker.on('failed', async (job, err) => {


### PR DESCRIPTION
Close #176

The warning was there because we reused the connection. Redis connections are cheap so it's fine to have a lot of them.