### PR TITLE
chore(client): update UI for db/app link and unlink logs

### DIFF
--- a/client/src/generated/graphql.tsx
+++ b/client/src/generated/graphql.tsx
@@ -254,8 +254,8 @@ export type QueryEnvVarsArgs = {
 
 export type Subscription = {
   __typename?: 'Subscription';
-  unlinkDatabaseLogs?: Maybe<Array<Scalars['String']>>;
-  linkDatabaseLogs?: Maybe<Array<Scalars['String']>>;
+  unlinkDatabaseLogs: RealTimeLog;
+  linkDatabaseLogs: RealTimeLog;
   createDatabaseLogs: RealTimeLog;
 };
 
@@ -610,7 +610,10 @@ export type LinkDatabaseLogsSubscriptionVariables = Exact<{ [key: string]: never
 
 export type LinkDatabaseLogsSubscription = (
   { __typename?: 'Subscription' }
-  & Pick<Subscription, 'linkDatabaseLogs'>
+  & { linkDatabaseLogs: (
+    { __typename?: 'RealTimeLog' }
+    & Pick<RealTimeLog, 'message' | 'type'>
+  ) }
 );
 
 export type UnlinkDatabaseLogsSubscriptionVariables = Exact<{ [key: string]: never; }>;
@@ -618,7 +621,10 @@ export type UnlinkDatabaseLogsSubscriptionVariables = Exact<{ [key: string]: nev
 
 export type UnlinkDatabaseLogsSubscription = (
   { __typename?: 'Subscription' }
-  & Pick<Subscription, 'unlinkDatabaseLogs'>
+  & { unlinkDatabaseLogs: (
+    { __typename?: 'RealTimeLog' }
+    & Pick<RealTimeLog, 'message' | 'type'>
+  ) }
 );
 
 
@@ -1333,7 +1339,10 @@ export type CreateDatabaseLogsSubscriptionHookResult = ReturnType<typeof useCrea
 export type CreateDatabaseLogsSubscriptionResult = Apollo.SubscriptionResult<CreateDatabaseLogsSubscription>;
 export const LinkDatabaseLogsDocument = gql`
     subscription LinkDatabaseLogs {
-  linkDatabaseLogs
+  linkDatabaseLogs {
+    message
+    type
+  }
 }
     `;
 
@@ -1359,7 +1368,10 @@ export type LinkDatabaseLogsSubscriptionHookResult = ReturnType<typeof useLinkDa
 export type LinkDatabaseLogsSubscriptionResult = Apollo.SubscriptionResult<LinkDatabaseLogsSubscription>;
 export const UnlinkDatabaseLogsDocument = gql`
     subscription UnlinkDatabaseLogs {
-  unlinkDatabaseLogs
+  unlinkDatabaseLogs {
+    message
+    type
+  }
 }
     `;
 

--- a/client/src/graphql/subscriptions/linkDatabaseLogs.graphql
+++ b/client/src/graphql/subscriptions/linkDatabaseLogs.graphql
@@ -1,3 +1,6 @@
 subscription LinkDatabaseLogs {
-  linkDatabaseLogs
+  linkDatabaseLogs {
+    message
+    type
+  }
 }

--- a/client/src/graphql/subscriptions/unlinkDatabaseLogs.graphql
+++ b/client/src/graphql/subscriptions/unlinkDatabaseLogs.graphql
@@ -1,3 +1,6 @@
 subscription UnlinkDatabaseLogs {
-  unlinkDatabaseLogs
+  unlinkDatabaseLogs {
+    message
+    type
+  }
 }

--- a/client/src/pages/database/index.tsx
+++ b/client/src/pages/database/index.tsx
@@ -8,6 +8,7 @@ import {
   useUnlinkDatabaseMutation,
   useUnlinkDatabaseLogsSubscription,
   useLinkDatabaseLogsSubscription,
+  RealTimeLog,
 } from '../../generated/graphql';
 import { useParams, Link } from 'react-router-dom';
 import Select from 'react-select';
@@ -26,10 +27,13 @@ export const Database = () => {
   const { id: databaseId } = useParams<{ id: string }>();
   const [isUnlinkModalOpen, setIsUnlinkModalOpen] = useState(false);
   const [isLinkModalOpen, setIsLinkModalOpen] = useState(false);
-  const [arrayOfUnlinkLogs, setArrayOfUnlinkLogs] = useState<string[]>([]);
-  const [arrayOfLinkLogs, setArrayOfLinkLogs] = useState<string[]>([]);
+  const [arrayOfUnlinkLogs, setArrayOfUnlinkLogs] = useState<RealTimeLog[]>([]);
+  const [arrayOfLinkLogs, setArrayOfLinkLogs] = useState<RealTimeLog[]>([]);
   const [appAboutToUnlink, setAppAboutToUnlink] = useState<string>();
   const [isTerminalVisible, setIsTerminalVisible] = useState(false);
+  const [processStatus, setProcessStatus] = useState<
+    'running' | 'notStarted' | 'finished'
+  >('notStarted');
   const [unlinkLoading, setUnlinkLoading] = useState(false);
   const [linkLoading, setLinkLoading] = useState(false);
 
@@ -60,21 +64,34 @@ export const Database = () => {
 
   useUnlinkDatabaseLogsSubscription({
     onSubscriptionData: (data) => {
-      const logsExist = data.subscriptionData.data?.unlinkDatabaseLogs?.[0];
-      if (logsExist)
+      const logsExist = data.subscriptionData.data?.unlinkDatabaseLogs;
+      if (logsExist) {
         setArrayOfUnlinkLogs((currentLogs) => {
           return [...currentLogs, logsExist];
         });
+        if (
+          logsExist.type === 'end:success' ||
+          logsExist.type === 'end:failure'
+        ) {
+          setProcessStatus('finished');
+        }
+      }
     },
   });
 
   useLinkDatabaseLogsSubscription({
     onSubscriptionData: (data) => {
-      const logsExist = data.subscriptionData.data?.linkDatabaseLogs?.[0];
+      const logsExist = data.subscriptionData.data?.linkDatabaseLogs;
       if (logsExist) {
         setArrayOfLinkLogs((currentLogs) => {
           return [...currentLogs, logsExist];
         });
+        if (
+          logsExist.type === 'end:success' ||
+          logsExist.type === 'end:failure'
+        ) {
+          setProcessStatus('finished');
+        }
       }
     },
   });
@@ -263,18 +280,18 @@ export const Database = () => {
                                 Linking <b>{selectedApp.value.name}</b> with{' '}
                                 <b>{database.name}</b>!
                               </p>
+                              <p className="text-gray-500 mb-2">
+                                Linking process usually takes a couple of
+                                minutes. Breathe in, breathe out, logs are about
+                                to appear below:
+                              </p>
                               <Terminal className={'w-6/6'}>
-                                <p className="text-green-400 mb-2">
-                                  Linking process usually takes a couple of
-                                  minutes. Breathe in, breathe out, logs are
-                                  about to appear below:
-                                </p>
                                 {arrayOfLinkLogs.map((log) => (
                                   <p
                                     key={arrayOfLinkLogs.indexOf(log)}
                                     className="text-s leading-5"
                                   >
-                                    {log}
+                                    {log.message}
                                   </p>
                                 ))}
                               </Terminal>
@@ -288,18 +305,21 @@ export const Database = () => {
                           )}
                         </ModalDescription>
                         <ModalButton
-                          ctaFn={() =>
-                            handleConnect(databaseId, selectedApp.value.id)
-                          }
+                          ctaFn={() => {
+                            setProcessStatus('running');
+                            handleConnect(databaseId, selectedApp.value.id);
+                          }}
                           ctaText={'Link'}
                           otherButtonText={'Cancel'}
                           isCtaLoading={isTerminalVisible ? false : linkLoading}
                           isCtaDisabled={isTerminalVisible}
+                          isOtherButtonDisabled={processStatus === 'running'}
                           closeModal={() => {
                             setIsLinkModalOpen(false);
                             refetch({ databaseId });
                             setLinkLoading(false);
                             setIsTerminalVisible(false);
+                            setProcessStatus('notStarted');
                           }}
                         />
                       </Modal>
@@ -362,18 +382,18 @@ export const Database = () => {
                                     Unlinking <b>{database.name}</b> from{' '}
                                     <b>{appAboutToUnlink}</b>!
                                   </p>
+                                  <p className="text-gray-500 mb-2">
+                                    Unlinking process usually takes a couple of
+                                    minutes. Breathe in, breathe out, logs are
+                                    about to appear below:
+                                  </p>
                                   <Terminal className={'w-6/6'}>
-                                    <p className="text-green-400 mb-2">
-                                      Unlinking process usually takes a couple
-                                      of minutes. Breathe in, breathe out, logs
-                                      are about to appear below:
-                                    </p>
                                     {arrayOfUnlinkLogs.map((log) => (
                                       <p
                                         key={arrayOfUnlinkLogs.indexOf(log)}
                                         className="text-s leading-5"
                                       >
-                                        {log}
+                                        {log.message}
                                       </p>
                                     ))}
                                   </Terminal>
@@ -387,11 +407,17 @@ export const Database = () => {
                               )}
                             </ModalDescription>
                             <ModalButton
-                              ctaFn={() => handleUnlink(database.id, app.id)}
+                              ctaFn={() => {
+                                setProcessStatus('running');
+                                handleUnlink(database.id, app.id);
+                              }}
                               ctaText={'Unlink'}
                               otherButtonText={'Cancel'}
                               isCtaLoading={
                                 isTerminalVisible ? false : unlinkLoading
+                              }
+                              isOtherButtonDisabled={
+                                processStatus === 'running'
                               }
                               isCtaDisabled={isTerminalVisible}
                               closeModal={() => {
@@ -400,6 +426,7 @@ export const Database = () => {
                                 setUnlinkLoading(false);
                                 setIsTerminalVisible(false);
                                 setAppAboutToUnlink('');
+                                setProcessStatus('notStarted');
                               }}
                             />
                           </Modal>

--- a/client/src/ui/components/Modal.tsx
+++ b/client/src/ui/components/Modal.tsx
@@ -50,6 +50,7 @@ interface ModalButtonProps {
   className?: string;
   ctaText: string;
   otherButtonText?: string;
+  isOtherButtonDisabled?: boolean;
   isCtaLoading: boolean;
   isCtaDisabled?: boolean;
   closeModal: () => void;
@@ -60,6 +61,7 @@ export const ModalButton = ({
   ctaText,
   className,
   otherButtonText,
+  isOtherButtonDisabled,
   isCtaLoading,
   isCtaDisabled,
   closeModal,
@@ -67,7 +69,11 @@ export const ModalButton = ({
 }: ModalButtonProps) => (
   <div className={cx('mt-8 flex justify-end space-x-3', className)}>
     {otherButtonText && (
-      <Button disabled={isCtaLoading} onClick={closeModal} color="grey">
+      <Button
+        disabled={isCtaLoading || isOtherButtonDisabled}
+        onClick={closeModal}
+        color="grey"
+      >
         {otherButtonText}
       </Button>
     )}

--- a/server/src/generated/graphql.ts
+++ b/server/src/generated/graphql.ts
@@ -122,7 +122,7 @@ export type AppLogsResult = {
 
 export type DatabaseInfoResult = {
   __typename?: 'DatabaseInfoResult';
-  info: Array<Maybe<Scalars['String']>>;
+  info: Array<Scalars['String']>;
 };
 
 export type DatabaseLogsResult = {
@@ -254,8 +254,8 @@ export type QueryEnvVarsArgs = {
 
 export type Subscription = {
   __typename?: 'Subscription';
-  unlinkDatabaseLogs?: Maybe<Array<Scalars['String']>>;
-  linkDatabaseLogs?: Maybe<Array<Scalars['String']>>;
+  unlinkDatabaseLogs: RealTimeLog;
+  linkDatabaseLogs: RealTimeLog;
   createDatabaseLogs: RealTimeLog;
 };
 
@@ -517,7 +517,7 @@ export type DatabaseResolvers<ContextType = any, ParentType extends ResolversPar
 export type RealTimeLogResolvers<ContextType = any, ParentType extends ResolversParentTypes['RealTimeLog'] = ResolversParentTypes['RealTimeLog']> = {
   message?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   type?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
-  __isTypeOf?: IsTypeOfResolverFn<ParentType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
 
 export type LoginResultResolvers<ContextType = any, ParentType extends ResolversParentTypes['LoginResult'] = ResolversParentTypes['LoginResult']> = {
@@ -574,7 +574,7 @@ export type UnsetEnvVarResultResolvers<ContextType = any, ParentType extends Res
 
 export type CreateDatabaseResultResolvers<ContextType = any, ParentType extends ResolversParentTypes['CreateDatabaseResult'] = ResolversParentTypes['CreateDatabaseResult']> = {
   result?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
-  __isTypeOf?: IsTypeOfResolverFn<ParentType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
 
 export type AppLogsResultResolvers<ContextType = any, ParentType extends ResolversParentTypes['AppLogsResult'] = ResolversParentTypes['AppLogsResult']> = {
@@ -583,7 +583,7 @@ export type AppLogsResultResolvers<ContextType = any, ParentType extends Resolve
 };
 
 export type DatabaseInfoResultResolvers<ContextType = any, ParentType extends ResolversParentTypes['DatabaseInfoResult'] = ResolversParentTypes['DatabaseInfoResult']> = {
-  info?: Resolver<Array<Maybe<ResolversTypes['String']>>, ParentType, ContextType>;
+  info?: Resolver<Array<ResolversTypes['String']>, ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
 
@@ -635,8 +635,8 @@ export type QueryResolvers<ContextType = any, ParentType extends ResolversParent
 };
 
 export type SubscriptionResolvers<ContextType = any, ParentType extends ResolversParentTypes['Subscription'] = ResolversParentTypes['Subscription']> = {
-  unlinkDatabaseLogs?: SubscriptionResolver<Maybe<Array<ResolversTypes['String']>>, "unlinkDatabaseLogs", ParentType, ContextType>;
-  linkDatabaseLogs?: SubscriptionResolver<Maybe<Array<ResolversTypes['String']>>, "linkDatabaseLogs", ParentType, ContextType>;
+  unlinkDatabaseLogs?: SubscriptionResolver<ResolversTypes['RealTimeLog'], "unlinkDatabaseLogs", ParentType, ContextType>;
+  linkDatabaseLogs?: SubscriptionResolver<ResolversTypes['RealTimeLog'], "linkDatabaseLogs", ParentType, ContextType>;
   createDatabaseLogs?: SubscriptionResolver<ResolversTypes['RealTimeLog'], "createDatabaseLogs", ParentType, ContextType>;
 };
 

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -196,8 +196,8 @@ const typeDefs = gql`
   }
 
   type Subscription {
-    unlinkDatabaseLogs: [String!]
-    linkDatabaseLogs: [String!]
+    unlinkDatabaseLogs: RealTimeLog!
+    linkDatabaseLogs: RealTimeLog!
     createDatabaseLogs: RealTimeLog!
   }
 

--- a/server/src/queues/unlinkDatabase.ts
+++ b/server/src/queues/unlinkDatabase.ts
@@ -51,18 +51,30 @@ const worker = new Worker(
     const dbType = dbTypeToDokkuPlugin(database.type);
 
     const ssh = await sshConnect();
-    await dokku.database.unlink(ssh, database.name, dbType, app.name, {
-      onStdout: (chunk) => {
-        pubsub.publish('DATABASE_UNLINKED', {
-          unlinkDatabaseLogs: [chunk.toString()],
-        });
-      },
-      onStderr: (chunk) => {
-        pubsub.publish('DATABASE_UNLINKED', {
-          unlinkDatabaseLogs: [chunk.toString()],
-        });
-      },
-    });
+    const res = await dokku.database.unlink(
+      ssh,
+      database.name,
+      dbType,
+      app.name,
+      {
+        onStdout: (chunk) => {
+          pubsub.publish('DATABASE_UNLINKED', {
+            unlinkDatabaseLogs: {
+              message: chunk.toString(),
+              type: 'stdout',
+            },
+          });
+        },
+        onStderr: (chunk) => {
+          pubsub.publish('DATABASE_UNLINKED', {
+            unlinkDatabaseLogs: {
+              message: chunk.toString(),
+              type: 'stderr',
+            },
+          });
+        },
+      }
+    );
 
     await prisma.database.update({
       where: { id: database.id },
@@ -76,6 +88,21 @@ const worker = new Worker(
     debug(
       `finishing unlinkDatabaseQueue for ${database.type} database ${database.name} from  ${app.name} app`
     );
+    if (!res.stderr) {
+      pubsub.publish('DATABASE_UNLINKED', {
+        unlinkDatabaseLogs: {
+          message: '',
+          type: 'end:success',
+        },
+      });
+    } else if (res.stderr) {
+      pubsub.publish('DATABASE_UNLINKED', {
+        unlinkDatabaseLogs: {
+          message: '',
+          type: 'end:failure',
+        },
+      });
+    }
   },
   { connection: redisClient }
 );


### PR DESCRIPTION
things fixed : 
- all real time logs now are of type `RealTimeLog` 
- moved Ledokku messages out of logs terminal
- you can't cancel link/unlink modal until it's finished (either failure or success) 
