### PR TITLE
feat: ledokku listen on port 80 instead of 4000 on production

### DIFF
--- a/ledokku-bootstrap.sh
+++ b/ledokku-bootstrap.sh
@@ -87,14 +87,14 @@ main() {
   docker tag ledokku/ledokku:0.3.3 dokku/ledokku:0.3.3
   dokku tags:deploy ledokku 0.3.3
 
+  # After app is deployed last step is to properly setup the ports
+  dokku proxy:ports-add ledokku http:80:4000
+  dokku proxy:ports-remove ledokku http:4000:4000
+
   echo "=== 🐳 ==="
-  echo "Installation succesful"
-  echo "Open you server ip in your browser with the port 4000"
-  echo "http://${DOKKU_SSH_HOST}:4000"
-  echo "=== 🚧 ==="
-  echo "If it is not connecting, try running this command on your server:"
-  echo "ufw allow 4000"
-  echo "=== 🚧 ==="
+  echo "Ledooku was successfully installed"
+  echo "Open you server ip in your browser"
+  echo "http://${DOKKU_SSH_HOST}"
   echo "=== 🐳 ==="
 }
 

--- a/ledokku-bootstrap.sh
+++ b/ledokku-bootstrap.sh
@@ -44,7 +44,7 @@ main() {
   echo
   echo "In your browser open https://github.com/settings/developers and click on the \"New OAuth App\" button."
   echo
-  echo "Add a name, a homepage url, and in the field \"Authorization callback URL\" set the value to \"http://"$DOKKU_SSH_HOST":4000\"."
+  echo "Add a name, a homepage url, and in the field \"Authorization callback URL\" set the value to \"http://"$DOKKU_SSH_HOST"\"."
   echo
   echo "Then click the \"Register application\" button. You should now be able to see the client id and client secret of the app."
   echo "=== 🐳 ==="

--- a/website/docs/advanced/manual-installation.mdx
+++ b/website/docs/advanced/manual-installation.mdx
@@ -50,7 +50,7 @@ dokku postgres:link ledokku ledokku
 
 In your browser open https://github.com/settings/developers and click on the "New OAuth App" button.
 
-Add a name, a homepage url, and in the field "Authorization callback URL" set the value to your ledokku ip address and port 4000. (eg: http://123.123.123.123:4000)
+Add a name, a homepage url, and in the field "Authorization callback URL" set the value to your ledokku ip address. (eg: http://123.123.123.123)
 
 <img alt="Github Oauth app setup" src={useBaseUrl('/img/githubApp.png')} />
 
@@ -81,27 +81,9 @@ Finally we deploy the tag to start our ledokku server.
 dokku tags:deploy ledokku 0.3.3
 ```
 
-:::note
-Before setting up the domain DNS in order to verify that the installation was successful, we need to open the port 4000. To do so, run the following command:
-
-```sh
-sudo ufw allow 4000
-```
-
-:::
-
-Now open you server ip in your browser with the port 4000 (eg: http://123.123.123.123:4000).
+Now open you server ip in your browser (eg: http://123.123.123.123).
 
 You should be able to see the ledokku admin 🎉.
-
-:::note
-We saw that the server is running properly, so we can remove the rule from the firewall.
-
-```sh
-sudo ufw deny 4000
-```
-
-:::
 
 Congrats, the ledokku app is running on your server 👏.
 

--- a/website/docs/advanced/manual-installation.mdx
+++ b/website/docs/advanced/manual-installation.mdx
@@ -81,6 +81,13 @@ Finally we deploy the tag to start our ledokku server.
 dokku tags:deploy ledokku 0.3.3
 ```
 
+After the app is deployed last step is to setup the proxy port.
+
+```sh
+dokku proxy:ports-add ledokku http:80:4000
+dokku proxy:ports-remove ledokku http:4000:4000
+```
+
 Now open you server ip in your browser (eg: http://123.123.123.123).
 
 You should be able to see the ledokku admin 🎉.


### PR DESCRIPTION
Close #197

No more port 4000 🎉

To migrate an existing server run:

```
dokku proxy:ports-add ledokku http:80:4000
dokku proxy:ports-remove ledokku http:4000:4000
```