### PR TITLE
chore(server): target node 12 for server compilation

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -29,6 +29,7 @@
     "node-fetch": "2.6.1",
     "node-ssh": "11.1.1",
     "sshpk": "1.16.1",
+    "tslib": "2.0.3",
     "yup": "0.29.3"
   },
   "devDependencies": {

--- a/server/tsconfig.json
+++ b/server/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es6",
+    "target": "ES2019",
     "lib": ["dom", "esnext"],
     "outDir": "build",
     "allowJs": false,
@@ -11,7 +11,8 @@
     "module": "commonjs",
     "moduleResolution": "node",
     "resolveJsonModule": true,
-    "sourceMap": true
+    "sourceMap": true,
+    "importHelpers": true
   },
   "exclude": ["node_modules"],
   "include": ["src/**/*.ts"]

--- a/yarn.lock
+++ b/yarn.lock
@@ -6738,7 +6738,7 @@ clone-response@^1.0.2:
   dependencies:
     mimic-response "^1.0.0"
 
-clsx@^1.1.1:
+clsx@1.1.1, clsx@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/clsx/-/clsx-1.1.1.tgz#98b3134f9abbdf23b2663491ace13c5c03a73188"
   integrity sha512-6/bPho624p3S2pMyvP5kKBPXnI3ufHLObBFCfgx+LkeR5lg2XYy2hqZqUf45ypD8COn2bhgGJSUE+l5dhNBieA==
@@ -17899,6 +17899,11 @@ tsconfig-paths@^3.9.0:
     json5 "^1.0.1"
     minimist "^1.2.0"
     strip-bom "^3.0.0"
+
+tslib@2.0.3:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.0.3.tgz#8e0741ac45fc0c226e58a17bfc3e64b9bc6ca61c"
+  integrity sha512-uZtkfKblCEQtZKBF6EBXVZeQNl82yqtDQdv+eck8u7tdPxjLu2/lp5/uPW+um2tpuxINHWy3GhiccY7QgEaVHQ==
 
 tslib@^1.10.0, tslib@^1.8.1, tslib@^1.9.0, tslib@^1.9.3:
   version "1.13.0"


### PR DESCRIPTION
The typescript server was targetting lower versions of node resulting in await being changed to polyfill for example. I changed the target to node 12 so the code should be faster to compile and run. As the project is quite small the wins will not change much for the user :D.

See https://github.com/microsoft/TypeScript/wiki/Node-Target-Mapping