### PR TITLE
feat(client): app domain managment

### DIFF
--- a/client/src/generated/graphql.tsx
+++ b/client/src/generated/graphql.tsx
@@ -52,6 +52,11 @@ export type DatabaseTypes =
   | 'MONGODB'
   | 'MYSQL';
 
+export type Domains = {
+  __typename?: 'Domains';
+  domains: Array<Maybe<Scalars['String']>>;
+};
+
 export type RealTimeLog = {
   __typename?: 'RealTimeLog';
   message?: Maybe<Scalars['String']>;
@@ -151,6 +156,21 @@ export type EnvVarsResult = {
   envVars: Array<EnvVar>;
 };
 
+export type SetDomainResult = {
+  __typename?: 'SetDomainResult';
+  result: Scalars['Boolean'];
+};
+
+export type AddDomainResult = {
+  __typename?: 'AddDomainResult';
+  result: Scalars['Boolean'];
+};
+
+export type RemoveDomainResult = {
+  __typename?: 'RemoveDomainResult';
+  result: Scalars['Boolean'];
+};
+
 export type SetupResult = {
   __typename?: 'SetupResult';
   canConnectSsh: Scalars['Boolean'];
@@ -202,6 +222,21 @@ export type DestroyAppInput = {
   appId: Scalars['String'];
 };
 
+export type AddDomainInput = {
+  appId: Scalars['String'];
+  domainName: Scalars['String'];
+};
+
+export type RemoveDomainInput = {
+  appId: Scalars['String'];
+  domainName: Scalars['String'];
+};
+
+export type SetDomainInput = {
+  appId: Scalars['String'];
+  domainName: Scalars['String'];
+};
+
 export type LinkDatabaseInput = {
   appId: Scalars['String'];
   databaseId: Scalars['String'];
@@ -229,6 +264,7 @@ export type Query = {
   setup: SetupResult;
   apps: Array<App>;
   app?: Maybe<App>;
+  domains: Domains;
   database?: Maybe<Database>;
   databases: Array<Database>;
   isPluginInstalled: IsPluginInstalledResult;
@@ -243,6 +279,11 @@ export type Query = {
 
 
 export type QueryAppArgs = {
+  appId: Scalars['String'];
+};
+
+
+export type QueryDomainsArgs = {
   appId: Scalars['String'];
 };
 
@@ -298,6 +339,9 @@ export type Subscription = {
 export type Mutation = {
   __typename?: 'Mutation';
   loginWithGithub?: Maybe<LoginResult>;
+  addDomain: AddDomainResult;
+  removeDomain: RemoveDomainResult;
+  setDomain: SetDomainResult;
   createApp: CreateAppResult;
   createDatabase: CreateDatabaseResult;
   setEnvVar: SetEnvVarResult;
@@ -314,6 +358,21 @@ export type Mutation = {
 
 export type MutationLoginWithGithubArgs = {
   code: Scalars['String'];
+};
+
+
+export type MutationAddDomainArgs = {
+  input: AddDomainInput;
+};
+
+
+export type MutationRemoveDomainArgs = {
+  input: RemoveDomainInput;
+};
+
+
+export type MutationSetDomainArgs = {
+  input: SetDomainInput;
 };
 
 
@@ -384,6 +443,19 @@ export type AddAppProxyPortMutationVariables = Exact<{
 export type AddAppProxyPortMutation = (
   { __typename?: 'Mutation' }
   & Pick<Mutation, 'addAppProxyPort'>
+);
+
+export type AddDomainMutationVariables = Exact<{
+  input: AddDomainInput;
+}>;
+
+
+export type AddDomainMutation = (
+  { __typename?: 'Mutation' }
+  & { addDomain: (
+    { __typename?: 'AddDomainResult' }
+    & Pick<AddDomainResult, 'result'>
+  ) }
 );
 
 export type CreateAppMutationVariables = Exact<{
@@ -477,6 +549,19 @@ export type RemoveAppProxyPortMutation = (
   & Pick<Mutation, 'removeAppProxyPort'>
 );
 
+export type RemoveDomainMutationVariables = Exact<{
+  input: RemoveDomainInput;
+}>;
+
+
+export type RemoveDomainMutation = (
+  { __typename?: 'Mutation' }
+  & { removeDomain: (
+    { __typename?: 'RemoveDomainResult' }
+    & Pick<RemoveDomainResult, 'result'>
+  ) }
+);
+
 export type RestartAppMutationVariables = Exact<{
   input: RestartAppInput;
 }>;
@@ -487,6 +572,19 @@ export type RestartAppMutation = (
   & { restartApp: (
     { __typename?: 'RestartAppResult' }
     & Pick<RestartAppResult, 'result'>
+  ) }
+);
+
+export type SetDomainMutationVariables = Exact<{
+  input: SetDomainInput;
+}>;
+
+
+export type SetDomainMutation = (
+  { __typename?: 'Mutation' }
+  & { setDomain: (
+    { __typename?: 'SetDomainResult' }
+    & Pick<SetDomainResult, 'result'>
   ) }
 );
 
@@ -654,6 +752,19 @@ export type DatabaseQuery = (
   )> }
 );
 
+export type DomainsQueryVariables = Exact<{
+  appId: Scalars['String'];
+}>;
+
+
+export type DomainsQuery = (
+  { __typename?: 'Query' }
+  & { domains: (
+    { __typename?: 'Domains' }
+    & Pick<Domains, 'domains'>
+  ) }
+);
+
 export type EnvVarsQueryVariables = Exact<{
   appId: Scalars['String'];
 }>;
@@ -769,6 +880,38 @@ export function useAddAppProxyPortMutation(baseOptions?: Apollo.MutationHookOpti
 export type AddAppProxyPortMutationHookResult = ReturnType<typeof useAddAppProxyPortMutation>;
 export type AddAppProxyPortMutationResult = Apollo.MutationResult<AddAppProxyPortMutation>;
 export type AddAppProxyPortMutationOptions = Apollo.BaseMutationOptions<AddAppProxyPortMutation, AddAppProxyPortMutationVariables>;
+export const AddDomainDocument = gql`
+    mutation addDomain($input: AddDomainInput!) {
+  addDomain(input: $input) {
+    result
+  }
+}
+    `;
+export type AddDomainMutationFn = Apollo.MutationFunction<AddDomainMutation, AddDomainMutationVariables>;
+
+/**
+ * __useAddDomainMutation__
+ *
+ * To run a mutation, you first call `useAddDomainMutation` within a React component and pass it any options that fit your needs.
+ * When your component renders, `useAddDomainMutation` returns a tuple that includes:
+ * - A mutate function that you can call at any time to execute the mutation
+ * - An object with fields that represent the current status of the mutation's execution
+ *
+ * @param baseOptions options that will be passed into the mutation, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options-2;
+ *
+ * @example
+ * const [addDomainMutation, { data, loading, error }] = useAddDomainMutation({
+ *   variables: {
+ *      input: // value for 'input'
+ *   },
+ * });
+ */
+export function useAddDomainMutation(baseOptions?: Apollo.MutationHookOptions<AddDomainMutation, AddDomainMutationVariables>) {
+        return Apollo.useMutation<AddDomainMutation, AddDomainMutationVariables>(AddDomainDocument, baseOptions);
+      }
+export type AddDomainMutationHookResult = ReturnType<typeof useAddDomainMutation>;
+export type AddDomainMutationResult = Apollo.MutationResult<AddDomainMutation>;
+export type AddDomainMutationOptions = Apollo.BaseMutationOptions<AddDomainMutation, AddDomainMutationVariables>;
 export const CreateAppDocument = gql`
     mutation createApp($name: String!) {
   createApp(input: {name: $name}) {
@@ -993,6 +1136,38 @@ export function useRemoveAppProxyPortMutation(baseOptions?: Apollo.MutationHookO
 export type RemoveAppProxyPortMutationHookResult = ReturnType<typeof useRemoveAppProxyPortMutation>;
 export type RemoveAppProxyPortMutationResult = Apollo.MutationResult<RemoveAppProxyPortMutation>;
 export type RemoveAppProxyPortMutationOptions = Apollo.BaseMutationOptions<RemoveAppProxyPortMutation, RemoveAppProxyPortMutationVariables>;
+export const RemoveDomainDocument = gql`
+    mutation removeDomain($input: RemoveDomainInput!) {
+  removeDomain(input: $input) {
+    result
+  }
+}
+    `;
+export type RemoveDomainMutationFn = Apollo.MutationFunction<RemoveDomainMutation, RemoveDomainMutationVariables>;
+
+/**
+ * __useRemoveDomainMutation__
+ *
+ * To run a mutation, you first call `useRemoveDomainMutation` within a React component and pass it any options that fit your needs.
+ * When your component renders, `useRemoveDomainMutation` returns a tuple that includes:
+ * - A mutate function that you can call at any time to execute the mutation
+ * - An object with fields that represent the current status of the mutation's execution
+ *
+ * @param baseOptions options that will be passed into the mutation, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options-2;
+ *
+ * @example
+ * const [removeDomainMutation, { data, loading, error }] = useRemoveDomainMutation({
+ *   variables: {
+ *      input: // value for 'input'
+ *   },
+ * });
+ */
+export function useRemoveDomainMutation(baseOptions?: Apollo.MutationHookOptions<RemoveDomainMutation, RemoveDomainMutationVariables>) {
+        return Apollo.useMutation<RemoveDomainMutation, RemoveDomainMutationVariables>(RemoveDomainDocument, baseOptions);
+      }
+export type RemoveDomainMutationHookResult = ReturnType<typeof useRemoveDomainMutation>;
+export type RemoveDomainMutationResult = Apollo.MutationResult<RemoveDomainMutation>;
+export type RemoveDomainMutationOptions = Apollo.BaseMutationOptions<RemoveDomainMutation, RemoveDomainMutationVariables>;
 export const RestartAppDocument = gql`
     mutation restartApp($input: RestartAppInput!) {
   restartApp(input: $input) {
@@ -1025,6 +1200,38 @@ export function useRestartAppMutation(baseOptions?: Apollo.MutationHookOptions<R
 export type RestartAppMutationHookResult = ReturnType<typeof useRestartAppMutation>;
 export type RestartAppMutationResult = Apollo.MutationResult<RestartAppMutation>;
 export type RestartAppMutationOptions = Apollo.BaseMutationOptions<RestartAppMutation, RestartAppMutationVariables>;
+export const SetDomainDocument = gql`
+    mutation setDomain($input: SetDomainInput!) {
+  setDomain(input: $input) {
+    result
+  }
+}
+    `;
+export type SetDomainMutationFn = Apollo.MutationFunction<SetDomainMutation, SetDomainMutationVariables>;
+
+/**
+ * __useSetDomainMutation__
+ *
+ * To run a mutation, you first call `useSetDomainMutation` within a React component and pass it any options that fit your needs.
+ * When your component renders, `useSetDomainMutation` returns a tuple that includes:
+ * - A mutate function that you can call at any time to execute the mutation
+ * - An object with fields that represent the current status of the mutation's execution
+ *
+ * @param baseOptions options that will be passed into the mutation, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options-2;
+ *
+ * @example
+ * const [setDomainMutation, { data, loading, error }] = useSetDomainMutation({
+ *   variables: {
+ *      input: // value for 'input'
+ *   },
+ * });
+ */
+export function useSetDomainMutation(baseOptions?: Apollo.MutationHookOptions<SetDomainMutation, SetDomainMutationVariables>) {
+        return Apollo.useMutation<SetDomainMutation, SetDomainMutationVariables>(SetDomainDocument, baseOptions);
+      }
+export type SetDomainMutationHookResult = ReturnType<typeof useSetDomainMutation>;
+export type SetDomainMutationResult = Apollo.MutationResult<SetDomainMutation>;
+export type SetDomainMutationOptions = Apollo.BaseMutationOptions<SetDomainMutation, SetDomainMutationVariables>;
 export const SetEnvVarDocument = gql`
     mutation setEnvVar($key: String!, $value: String!, $appId: String!) {
   setEnvVar(input: {key: $key, value: $value, appId: $appId}) {
@@ -1444,6 +1651,39 @@ export function useDatabaseLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<D
 export type DatabaseQueryHookResult = ReturnType<typeof useDatabaseQuery>;
 export type DatabaseLazyQueryHookResult = ReturnType<typeof useDatabaseLazyQuery>;
 export type DatabaseQueryResult = Apollo.QueryResult<DatabaseQuery, DatabaseQueryVariables>;
+export const DomainsDocument = gql`
+    query domains($appId: String!) {
+  domains(appId: $appId) {
+    domains
+  }
+}
+    `;
+
+/**
+ * __useDomainsQuery__
+ *
+ * To run a query within a React component, call `useDomainsQuery` and pass it any options that fit your needs.
+ * When your component renders, `useDomainsQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * you can use to render your UI.
+ *
+ * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
+ *
+ * @example
+ * const { data, loading, error } = useDomainsQuery({
+ *   variables: {
+ *      appId: // value for 'appId'
+ *   },
+ * });
+ */
+export function useDomainsQuery(baseOptions?: Apollo.QueryHookOptions<DomainsQuery, DomainsQueryVariables>) {
+        return Apollo.useQuery<DomainsQuery, DomainsQueryVariables>(DomainsDocument, baseOptions);
+      }
+export function useDomainsLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<DomainsQuery, DomainsQueryVariables>) {
+          return Apollo.useLazyQuery<DomainsQuery, DomainsQueryVariables>(DomainsDocument, baseOptions);
+        }
+export type DomainsQueryHookResult = ReturnType<typeof useDomainsQuery>;
+export type DomainsLazyQueryHookResult = ReturnType<typeof useDomainsLazyQuery>;
+export type DomainsQueryResult = Apollo.QueryResult<DomainsQuery, DomainsQueryVariables>;
 export const EnvVarsDocument = gql`
     query envVars($appId: String!) {
   envVars(appId: $appId) {

--- a/client/src/graphql/mutations/addDomain.graphql
+++ b/client/src/graphql/mutations/addDomain.graphql
@@ -1,0 +1,5 @@
+mutation addDomain($input: AddDomainInput!) {
+  addDomain(input: $input) {
+    result
+  }
+}

--- a/client/src/graphql/mutations/removeDomain.graphql
+++ b/client/src/graphql/mutations/removeDomain.graphql
@@ -1,0 +1,5 @@
+mutation removeDomain($input: RemoveDomainInput!) {
+  removeDomain(input: $input) {
+    result
+  }
+}

--- a/client/src/graphql/mutations/setDomain.graphql
+++ b/client/src/graphql/mutations/setDomain.graphql
@@ -1,0 +1,5 @@
+mutation setDomain($input: SetDomainInput!) {
+  setDomain(input: $input) {
+    result
+  }
+}

--- a/client/src/graphql/queries/domains.graphql
+++ b/client/src/graphql/queries/domains.graphql
@@ -1,0 +1,5 @@
+query domains($appId: String!) {
+  domains(appId: $appId) {
+    domains
+  }
+}

--- a/client/src/modules/domains/AddAppDomain.tsx
+++ b/client/src/modules/domains/AddAppDomain.tsx
@@ -2,7 +2,7 @@ import { useFormik } from 'formik';
 import * as yup from 'yup';
 import { toast } from 'react-toastify';
 import { useAddDomainMutation } from '../../generated/graphql';
-import { FormHelper, FormInput, FormLabel, Button } from '../../ui';
+import { FormHelper, FormInput, Button } from '../../ui';
 
 const addAppDomainYupSchema = yup.object().shape({
   domainName: yup.string().required('Domain name is required'),

--- a/client/src/modules/domains/AddAppDomain.tsx
+++ b/client/src/modules/domains/AddAppDomain.tsx
@@ -35,6 +35,7 @@ export const AddAppDomain = ({ appId, appDomainsRefetch }: AddDomainProps) => {
 
         await appDomainsRefetch();
         toast.success('Domain added successfully');
+        formik.resetForm();
       } catch (error) {
         toast.error(error.message);
       }

--- a/client/src/modules/domains/AddAppDomain.tsx
+++ b/client/src/modules/domains/AddAppDomain.tsx
@@ -1,0 +1,72 @@
+import { useFormik } from 'formik';
+import * as yup from 'yup';
+import { toast } from 'react-toastify';
+import { useAddDomainMutation } from '../../generated/graphql';
+import { FormHelper, FormInput, FormLabel, Button } from '../../ui';
+
+const addAppDomainYupSchema = yup.object().shape({
+  domainName: yup.string().required('Domain name is required'),
+});
+
+interface AddDomainProps {
+  appId: string;
+  appDomainsRefetch: () => Promise<any>;
+}
+
+export const AddAppDomain = ({ appId, appDomainsRefetch }: AddDomainProps) => {
+  const [addDomainMutation] = useAddDomainMutation();
+
+  const formik = useFormik<{ domainName: string }>({
+    initialValues: {
+      domainName: '',
+    },
+    validateOnChange: true,
+    validationSchema: addAppDomainYupSchema,
+    onSubmit: async (values) => {
+      try {
+        await addDomainMutation({
+          variables: {
+            input: {
+              appId,
+              domainName: values.domainName,
+            },
+          },
+        });
+
+        await appDomainsRefetch();
+        toast.success('Domain added successfully');
+      } catch (error) {
+        toast.error(error.message);
+      }
+    },
+  });
+
+  return (
+    <>
+      <p className="text-gray-400 text-sm mb-2 mt-4">
+        To add new domain to the app, fill in the form below
+      </p>
+      <div className="grid md:grid-cols-3 gap-2">
+        <FormInput
+          className="col-span-2"
+          name="domainName"
+          value={formik.values.domainName}
+          onChange={formik.handleChange}
+          onBlur={formik.handleBlur}
+          error={Boolean(formik.errors.domainName && formik.touched.domainName)}
+        />
+        <Button
+          disabled={!!formik.errors.domainName || !formik.values.domainName}
+          color="grey"
+          isLoading={formik.isSubmitting}
+          onClick={() => formik.handleSubmit()}
+        >
+          Add
+        </Button>
+        {formik.errors.domainName ? (
+          <FormHelper status="error">{formik.errors.domainName}</FormHelper>
+        ) : null}
+      </div>
+    </>
+  );
+};

--- a/client/src/modules/domains/AppDomains.tsx
+++ b/client/src/modules/domains/AppDomains.tsx
@@ -1,0 +1,113 @@
+import { toast } from 'react-toastify';
+import { DomainsDocument } from '../../generated/graphql';
+import {
+  useAppByIdQuery,
+  useRemoveDomainMutation,
+  useDomainsQuery,
+} from '../../generated/graphql';
+import { Button } from '../../ui';
+import { TrashBinIcon } from '../../ui/icons/TrashBinIcon';
+import { AddAppDomain } from './AddAppDomain';
+
+interface AppDomainProps {
+  appId: string;
+}
+
+export const AppDomains = ({ appId }: AppDomainProps) => {
+  const { data, loading /* error */ } = useAppByIdQuery({
+    variables: {
+      appId,
+    },
+    ssr: false,
+    skip: !appId,
+  });
+
+  const {
+    data: domainsData,
+    loading: domainsDataLoading,
+    refetch: appDomainsRefetch,
+  } = useDomainsQuery({
+    variables: {
+      appId,
+    },
+  });
+
+  const [
+    removeDomainMutation,
+    { loading: removeDomainMutationLoading },
+  ] = useRemoveDomainMutation();
+
+  const handleRemoveDomain = async (domain: string) => {
+    try {
+      await removeDomainMutation({
+        variables: {
+          input: {
+            appId,
+            domainName: domain,
+          },
+        },
+        refetchQueries: [{ query: DomainsDocument, variables: { appId } }],
+      });
+
+      toast.success('Domain removed successfully');
+    } catch (error) {
+      toast.error(error.message);
+    }
+  };
+
+  if (!data) {
+    return null;
+  }
+
+  // // TODO display error
+
+  if (loading) {
+    // TODO nice loading
+    return <p>Loading...</p>;
+  }
+
+  const { app } = data;
+
+  if (!app) {
+    // TODO nice 404
+    return <p>App not found.</p>;
+  }
+
+  return (
+    <>
+      <h1 className="text-md font-bold mt-7">Domain managment</h1>
+      <p className="text-gray-400 text-sm mb-2">
+        List of domains you have added to {app.name} app
+      </p>
+      {domainsData &&
+        !domainsDataLoading &&
+        domainsData.domains.domains.length > 0 &&
+        domainsData.domains.domains.map((domain) => (
+          <>
+            {domain && domain.length > 0 ? (
+              <div className="grid sm:grid-cols-2 md:grid-cols-2 lg:grid-cols-2 xl:grid-cols-2 gap-4">
+                <p className="text-blue-600 mt-2">{domain}</p>
+                <div className="flex items-end">
+                  <Button
+                    isLoading={removeDomainMutationLoading}
+                    className="ml-2"
+                    color="red"
+                    onClick={() => handleRemoveDomain(domain)}
+                    variant="outline"
+                    size={24}
+                  >
+                    <TrashBinIcon size={24} />
+                  </Button>
+                </div>
+              </div>
+            ) : (
+              <p className="text-gray-400 text-sm mt-4">
+                Currently you haven't added any domains to your app
+              </p>
+            )}
+          </>
+        ))}
+      <AddAppDomain appId={appId} appDomainsRefetch={appDomainsRefetch} />
+    </>
+  );
+};

--- a/client/src/modules/domains/AppDomains.tsx
+++ b/client/src/modules/domains/AppDomains.tsx
@@ -89,7 +89,7 @@ export const AppDomains = ({ appId }: AppDomainProps) => {
                 <p className="text-blue-600 mt-2">{domain}</p>
                 <div className="flex items-end">
                   <Button
-                    isLoading={removeDomainMutationLoading}
+                    disabled={removeDomainMutationLoading}
                     className="ml-2"
                     color="red"
                     onClick={() => handleRemoveDomain(domain)}

--- a/client/src/pages/app/settings.tsx
+++ b/client/src/pages/app/settings.tsx
@@ -12,6 +12,7 @@ import { useFormik } from 'formik';
 import { TabNav, TabNavLink, Button, FormInput, FormHelper } from '../../ui';
 import { AppProxyPorts } from '../../modules/appProxyPorts/AppProxyPorts';
 import { AppRestart } from '../../modules/app/AppRestart';
+import { AppDomains } from '../../modules/domains/AppDomains';
 
 export const Settings = () => {
   const { id: appId } = useParams<{ id: string }>();
@@ -152,6 +153,9 @@ export const Settings = () => {
                 </Button>
               </div>
             </form>
+          </div>
+          <div className="ml-5 py-20">
+            <AppDomains appId={appId} />
           </div>
         </div>
       </div>

--- a/client/src/pages/app/settings.tsx
+++ b/client/src/pages/app/settings.tsx
@@ -111,6 +111,7 @@ export const Settings = () => {
             </div>
             <AppProxyPorts appId={app.id} />
             <AppRestart appId={app.id} />
+            <AppDomains appId={appId} />
             <h1 className="text-md font-bold py-5">Delete app</h1>
             <p className="text-gray-400">
               This action cannot be undone. This will permanently delete{' '}
@@ -146,9 +147,6 @@ export const Settings = () => {
                 </Button>
               </div>
             </form>
-          </div>
-          <div className="ml-5 py-20">
-            <AppDomains appId={appId} />
           </div>
         </div>
       </div>

--- a/client/src/pages/app/settings.tsx
+++ b/client/src/pages/app/settings.tsx
@@ -40,13 +40,11 @@ export const Settings = () => {
       ),
   });
 
-  const { data: domainsRes } = useDomainsQuery({
+  const { data: domainsData } = useDomainsQuery({
     variables: {
       appId,
     },
   });
-
-  console.log(domainsRes);
 
   const formik = useFormik<{ appName: string }>({
     initialValues: {

--- a/client/src/pages/app/settings.tsx
+++ b/client/src/pages/app/settings.tsx
@@ -5,7 +5,6 @@ import { Header } from '../../modules/layout/Header';
 import {
   useAppByIdQuery,
   useDestroyAppMutation,
-  useDomainsQuery,
   DashboardDocument,
 } from '../../generated/graphql';
 import { useFormik } from 'formik';

--- a/client/src/pages/app/settings.tsx
+++ b/client/src/pages/app/settings.tsx
@@ -5,6 +5,7 @@ import { Header } from '../../modules/layout/Header';
 import {
   useAppByIdQuery,
   useDestroyAppMutation,
+  useDomainsQuery,
   DashboardDocument,
 } from '../../generated/graphql';
 import { useFormik } from 'formik';
@@ -38,6 +39,14 @@ export const Settings = () => {
         (val) => val === data?.app?.name
       ),
   });
+
+  const { data: domainsRes } = useDomainsQuery({
+    variables: {
+      appId,
+    },
+  });
+
+  console.log(domainsRes);
 
   const formik = useFormik<{ appName: string }>({
     initialValues: {

--- a/client/src/pages/app/settings.tsx
+++ b/client/src/pages/app/settings.tsx
@@ -41,12 +41,6 @@ export const Settings = () => {
       ),
   });
 
-  const { data: domainsData } = useDomainsQuery({
-    variables: {
-      appId,
-    },
-  });
-
   const formik = useFormik<{ appName: string }>({
     initialValues: {
       appName: '',

--- a/server/src/generated/graphql.ts
+++ b/server/src/generated/graphql.ts
@@ -52,6 +52,11 @@ export type DatabaseTypes =
   | 'MONGODB'
   | 'MYSQL';
 
+export type Domains = {
+  __typename?: 'Domains';
+  domains: Array<Maybe<Scalars['String']>>;
+};
+
 export type RealTimeLog = {
   __typename?: 'RealTimeLog';
   message?: Maybe<Scalars['String']>;
@@ -151,6 +156,21 @@ export type EnvVarsResult = {
   envVars: Array<EnvVar>;
 };
 
+export type SetDomainResult = {
+  __typename?: 'SetDomainResult';
+  result: Scalars['Boolean'];
+};
+
+export type AddDomainResult = {
+  __typename?: 'AddDomainResult';
+  result: Scalars['Boolean'];
+};
+
+export type RemoveDomainResult = {
+  __typename?: 'RemoveDomainResult';
+  result: Scalars['Boolean'];
+};
+
 export type SetupResult = {
   __typename?: 'SetupResult';
   canConnectSsh: Scalars['Boolean'];
@@ -202,6 +222,21 @@ export type DestroyAppInput = {
   appId: Scalars['String'];
 };
 
+export type AddDomainInput = {
+  appId: Scalars['String'];
+  domainName: Scalars['String'];
+};
+
+export type RemoveDomainInput = {
+  appId: Scalars['String'];
+  domainName: Scalars['String'];
+};
+
+export type SetDomainInput = {
+  appId: Scalars['String'];
+  domainName: Scalars['String'];
+};
+
 export type LinkDatabaseInput = {
   appId: Scalars['String'];
   databaseId: Scalars['String'];
@@ -229,6 +264,7 @@ export type Query = {
   setup: SetupResult;
   apps: Array<App>;
   app?: Maybe<App>;
+  domains: Domains;
   database?: Maybe<Database>;
   databases: Array<Database>;
   isPluginInstalled: IsPluginInstalledResult;
@@ -243,6 +279,11 @@ export type Query = {
 
 
 export type QueryAppArgs = {
+  appId: Scalars['String'];
+};
+
+
+export type QueryDomainsArgs = {
   appId: Scalars['String'];
 };
 
@@ -298,6 +339,9 @@ export type Subscription = {
 export type Mutation = {
   __typename?: 'Mutation';
   loginWithGithub?: Maybe<LoginResult>;
+  addDomain: AddDomainResult;
+  removeDomain: RemoveDomainResult;
+  setDomain: SetDomainResult;
   createApp: CreateAppResult;
   createDatabase: CreateDatabaseResult;
   setEnvVar: SetEnvVarResult;
@@ -314,6 +358,21 @@ export type Mutation = {
 
 export type MutationLoginWithGithubArgs = {
   code: Scalars['String'];
+};
+
+
+export type MutationAddDomainArgs = {
+  input: AddDomainInput;
+};
+
+
+export type MutationRemoveDomainArgs = {
+  input: RemoveDomainInput;
+};
+
+
+export type MutationSetDomainArgs = {
+  input: SetDomainInput;
 };
 
 
@@ -462,6 +521,7 @@ export type ResolversTypes = {
   AppBuildStatus: AppBuildStatus;
   Database: ResolverTypeWrapper<Database>;
   DatabaseTypes: DatabaseTypes;
+  Domains: ResolverTypeWrapper<Domains>;
   RealTimeLog: ResolverTypeWrapper<RealTimeLog>;
   LoginResult: ResolverTypeWrapper<LoginResult>;
   CreateAppResult: ResolverTypeWrapper<CreateAppResult>;
@@ -482,6 +542,9 @@ export type ResolversTypes = {
   IsDatabaseLinkedResult: ResolverTypeWrapper<IsDatabaseLinkedResult>;
   EnvVar: ResolverTypeWrapper<EnvVar>;
   EnvVarsResult: ResolverTypeWrapper<EnvVarsResult>;
+  SetDomainResult: ResolverTypeWrapper<SetDomainResult>;
+  AddDomainResult: ResolverTypeWrapper<AddDomainResult>;
+  RemoveDomainResult: ResolverTypeWrapper<RemoveDomainResult>;
   SetupResult: ResolverTypeWrapper<SetupResult>;
   IsPluginInstalledResult: ResolverTypeWrapper<IsPluginInstalledResult>;
   AppProxyPort: ResolverTypeWrapper<AppProxyPort>;
@@ -492,6 +555,9 @@ export type ResolversTypes = {
   SetEnvVarInput: SetEnvVarInput;
   UnsetEnvVarInput: UnsetEnvVarInput;
   DestroyAppInput: DestroyAppInput;
+  AddDomainInput: AddDomainInput;
+  RemoveDomainInput: RemoveDomainInput;
+  SetDomainInput: SetDomainInput;
   LinkDatabaseInput: LinkDatabaseInput;
   DestroyDatabaseInput: DestroyDatabaseInput;
   AddAppProxyPortInput: AddAppProxyPortInput;
@@ -511,6 +577,7 @@ export type ResolversParentTypes = {
   String: Scalars['String'];
   AppBuild: AppBuild;
   Database: Database;
+  Domains: Domains;
   RealTimeLog: RealTimeLog;
   LoginResult: LoginResult;
   CreateAppResult: CreateAppResult;
@@ -531,6 +598,9 @@ export type ResolversParentTypes = {
   IsDatabaseLinkedResult: IsDatabaseLinkedResult;
   EnvVar: EnvVar;
   EnvVarsResult: EnvVarsResult;
+  SetDomainResult: SetDomainResult;
+  AddDomainResult: AddDomainResult;
+  RemoveDomainResult: RemoveDomainResult;
   SetupResult: SetupResult;
   IsPluginInstalledResult: IsPluginInstalledResult;
   AppProxyPort: AppProxyPort;
@@ -541,6 +611,9 @@ export type ResolversParentTypes = {
   SetEnvVarInput: SetEnvVarInput;
   UnsetEnvVarInput: UnsetEnvVarInput;
   DestroyAppInput: DestroyAppInput;
+  AddDomainInput: AddDomainInput;
+  RemoveDomainInput: RemoveDomainInput;
+  SetDomainInput: SetDomainInput;
   LinkDatabaseInput: LinkDatabaseInput;
   DestroyDatabaseInput: DestroyDatabaseInput;
   AddAppProxyPortInput: AddAppProxyPortInput;
@@ -575,6 +648,11 @@ export type DatabaseResolvers<ContextType = any, ParentType extends ResolversPar
   type?: Resolver<ResolversTypes['DatabaseTypes'], ParentType, ContextType>;
   createdAt?: Resolver<ResolversTypes['DateTime'], ParentType, ContextType>;
   apps?: Resolver<Maybe<Array<ResolversTypes['App']>>, ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+};
+
+export type DomainsResolvers<ContextType = any, ParentType extends ResolversParentTypes['Domains'] = ResolversParentTypes['Domains']> = {
+  domains?: Resolver<Array<Maybe<ResolversTypes['String']>>, ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
 
@@ -677,6 +755,21 @@ export type EnvVarsResultResolvers<ContextType = any, ParentType extends Resolve
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
 
+export type SetDomainResultResolvers<ContextType = any, ParentType extends ResolversParentTypes['SetDomainResult'] = ResolversParentTypes['SetDomainResult']> = {
+  result?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+};
+
+export type AddDomainResultResolvers<ContextType = any, ParentType extends ResolversParentTypes['AddDomainResult'] = ResolversParentTypes['AddDomainResult']> = {
+  result?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+};
+
+export type RemoveDomainResultResolvers<ContextType = any, ParentType extends ResolversParentTypes['RemoveDomainResult'] = ResolversParentTypes['RemoveDomainResult']> = {
+  result?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+};
+
 export type SetupResultResolvers<ContextType = any, ParentType extends ResolversParentTypes['SetupResult'] = ResolversParentTypes['SetupResult']> = {
   canConnectSsh?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
   sshPublicKey?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
@@ -699,6 +792,7 @@ export type QueryResolvers<ContextType = any, ParentType extends ResolversParent
   setup?: Resolver<ResolversTypes['SetupResult'], ParentType, ContextType>;
   apps?: Resolver<Array<ResolversTypes['App']>, ParentType, ContextType>;
   app?: Resolver<Maybe<ResolversTypes['App']>, ParentType, ContextType, RequireFields<QueryAppArgs, 'appId'>>;
+  domains?: Resolver<ResolversTypes['Domains'], ParentType, ContextType, RequireFields<QueryDomainsArgs, 'appId'>>;
   database?: Resolver<Maybe<ResolversTypes['Database']>, ParentType, ContextType, RequireFields<QueryDatabaseArgs, 'databaseId'>>;
   databases?: Resolver<Array<ResolversTypes['Database']>, ParentType, ContextType>;
   isPluginInstalled?: Resolver<ResolversTypes['IsPluginInstalledResult'], ParentType, ContextType, RequireFields<QueryIsPluginInstalledArgs, 'pluginName'>>;
@@ -720,6 +814,9 @@ export type SubscriptionResolvers<ContextType = any, ParentType extends Resolver
 
 export type MutationResolvers<ContextType = any, ParentType extends ResolversParentTypes['Mutation'] = ResolversParentTypes['Mutation']> = {
   loginWithGithub?: Resolver<Maybe<ResolversTypes['LoginResult']>, ParentType, ContextType, RequireFields<MutationLoginWithGithubArgs, 'code'>>;
+  addDomain?: Resolver<ResolversTypes['AddDomainResult'], ParentType, ContextType, RequireFields<MutationAddDomainArgs, 'input'>>;
+  removeDomain?: Resolver<ResolversTypes['RemoveDomainResult'], ParentType, ContextType, RequireFields<MutationRemoveDomainArgs, 'input'>>;
+  setDomain?: Resolver<ResolversTypes['SetDomainResult'], ParentType, ContextType, RequireFields<MutationSetDomainArgs, 'input'>>;
   createApp?: Resolver<ResolversTypes['CreateAppResult'], ParentType, ContextType, RequireFields<MutationCreateAppArgs, 'input'>>;
   createDatabase?: Resolver<ResolversTypes['CreateDatabaseResult'], ParentType, ContextType, RequireFields<MutationCreateDatabaseArgs, 'input'>>;
   setEnvVar?: Resolver<ResolversTypes['SetEnvVarResult'], ParentType, ContextType, RequireFields<MutationSetEnvVarArgs, 'input'>>;
@@ -742,6 +839,7 @@ export type Resolvers<ContextType = any> = {
   App?: AppResolvers<ContextType>;
   AppBuild?: AppBuildResolvers<ContextType>;
   Database?: DatabaseResolvers<ContextType>;
+  Domains?: DomainsResolvers<ContextType>;
   RealTimeLog?: RealTimeLogResolvers<ContextType>;
   LoginResult?: LoginResultResolvers<ContextType>;
   CreateAppResult?: CreateAppResultResolvers<ContextType>;
@@ -761,6 +859,9 @@ export type Resolvers<ContextType = any> = {
   IsDatabaseLinkedResult?: IsDatabaseLinkedResultResolvers<ContextType>;
   EnvVar?: EnvVarResolvers<ContextType>;
   EnvVarsResult?: EnvVarsResultResolvers<ContextType>;
+  SetDomainResult?: SetDomainResultResolvers<ContextType>;
+  AddDomainResult?: AddDomainResultResolvers<ContextType>;
+  RemoveDomainResult?: RemoveDomainResultResolvers<ContextType>;
   SetupResult?: SetupResultResolvers<ContextType>;
   IsPluginInstalledResult?: IsPluginInstalledResultResolvers<ContextType>;
   AppProxyPort?: AppProxyPortResolvers<ContextType>;

--- a/server/src/graphql/mutations/addDomain.ts
+++ b/server/src/graphql/mutations/addDomain.ts
@@ -1,0 +1,32 @@
+import { MutationResolvers } from '../../generated/graphql';
+import { dokku } from '../../lib/dokku';
+import { sshConnect } from '../../lib/ssh';
+import { prisma } from '../../prisma';
+
+export const addDomain: MutationResolvers['addDomain'] = async (
+  _,
+  { input },
+  { userId }
+) => {
+  if (!userId) {
+    throw new Error('Unauthorized');
+  }
+
+  const app = await prisma.app.findOne({
+    where: {
+      id: input.appId,
+    },
+  });
+
+  if (!app) {
+    throw new Error(`App with ID ${input.appId} not found`);
+  }
+
+  const { domainName } = input;
+
+  const ssh = await sshConnect();
+
+  await dokku.domains.add(ssh, app.name, domainName);
+
+  return { result: true };
+};

--- a/server/src/graphql/mutations/index.ts
+++ b/server/src/graphql/mutations/index.ts
@@ -1,3 +1,6 @@
+import { removeDomain } from './removeDomain';
+import { addDomain } from './addDomain';
+import { setDomain } from './setDomain';
 import { unsetEnvVar } from './unsetEnvVar';
 import { setEnvVar } from './setEnvVar';
 import { loginWithGithub } from './loginWithGithub';
@@ -24,4 +27,7 @@ export const mutations = {
   unlinkDatabase,
   addAppProxyPort,
   removeAppProxyPort,
+  removeDomain,
+  addDomain,
+  setDomain,
 };

--- a/server/src/graphql/mutations/removeDomain.ts
+++ b/server/src/graphql/mutations/removeDomain.ts
@@ -1,0 +1,32 @@
+import { MutationResolvers } from '../../generated/graphql';
+import { dokku } from '../../lib/dokku';
+import { sshConnect } from '../../lib/ssh';
+import { prisma } from '../../prisma';
+
+export const removeDomain: MutationResolvers['removeDomain'] = async (
+  _,
+  { input },
+  { userId }
+) => {
+  if (!userId) {
+    throw new Error('Unauthorized');
+  }
+
+  const app = await prisma.app.findOne({
+    where: {
+      id: input.appId,
+    },
+  });
+
+  if (!app) {
+    throw new Error(`App with ID ${input.appId} not found`);
+  }
+
+  const { domainName } = input;
+
+  const ssh = await sshConnect();
+
+  await dokku.domains.remove(ssh, app.name, domainName);
+
+  return { result: true };
+};

--- a/server/src/graphql/mutations/setDomain.ts
+++ b/server/src/graphql/mutations/setDomain.ts
@@ -1,0 +1,32 @@
+import { MutationResolvers } from '../../generated/graphql';
+import { dokku } from '../../lib/dokku';
+import { sshConnect } from '../../lib/ssh';
+import { prisma } from '../../prisma';
+
+export const setDomain: MutationResolvers['setDomain'] = async (
+  _,
+  { input },
+  { userId }
+) => {
+  if (!userId) {
+    throw new Error('Unauthorized');
+  }
+
+  const app = await prisma.app.findOne({
+    where: {
+      id: input.appId,
+    },
+  });
+
+  if (!app) {
+    throw new Error(`App with ID ${input.appId} not found`);
+  }
+
+  const { domainName } = input;
+
+  const ssh = await sshConnect();
+
+  await dokku.domains.set(ssh, app.name, domainName);
+
+  return { result: true };
+};

--- a/server/src/graphql/queries/domains.ts
+++ b/server/src/graphql/queries/domains.ts
@@ -1,0 +1,30 @@
+import { QueryResolvers } from '../../generated/graphql';
+import { sshConnect } from '../../lib/ssh';
+import { dokku } from '../../lib/dokku';
+import { prisma } from '../../prisma';
+
+export const domains: QueryResolvers['domains'] = async (
+  _,
+  { appId },
+  { userId }
+) => {
+  if (!userId) {
+    throw new Error('Unauthorized');
+  }
+
+  const app = await prisma.app.findOne({
+    where: {
+      id: appId,
+    },
+  });
+
+  if (!app) {
+    throw new Error(`App with ID ${appId} not found`);
+  }
+
+  const ssh = await sshConnect();
+
+  const domains = await dokku.domains.report(ssh, app.name);
+
+  return { domains: domains };
+};

--- a/server/src/graphql/queries/index.ts
+++ b/server/src/graphql/queries/index.ts
@@ -11,6 +11,7 @@ import { databaseInfo } from './databaseInfo';
 import { databaseLogs } from './databaseLogs';
 import { isDatabaseLinked } from './isDatabaseLinked';
 import { appProxyPorts } from './appProxyPorts';
+import { domains } from './domains';
 
 export const queries = {
   app,
@@ -19,6 +20,7 @@ export const queries = {
   databases,
   databaseInfo,
   databaseLogs,
+  domains,
   isDatabaseLinked,
   dokkuPlugins,
   appLogs,

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -54,6 +54,10 @@ const typeDefs = gql`
     MYSQL
   }
 
+  type Domains {
+    domains: [String]!
+  }
+
   type RealTimeLog {
     message: String
     type: String
@@ -134,6 +138,18 @@ const typeDefs = gql`
     envVars: [EnvVar!]!
   }
 
+  type SetDomainResult {
+    result: Boolean!
+  }
+
+  type AddDomainResult {
+    result: Boolean!
+  }
+
+  type RemoveDomainResult {
+    result: Boolean!
+  }
+
   type SetupResult {
     canConnectSsh: Boolean!
     sshPublicKey: String!
@@ -182,6 +198,21 @@ const typeDefs = gql`
     appId: String!
   }
 
+  input AddDomainInput {
+    appId: String!
+    domainName: String!
+  }
+
+  input RemoveDomainInput {
+    appId: String!
+    domainName: String!
+  }
+
+  input SetDomainInput {
+    appId: String!
+    domainName: String!
+  }
+
   input LinkDatabaseInput {
     appId: String!
     databaseId: String!
@@ -208,6 +239,7 @@ const typeDefs = gql`
     setup: SetupResult!
     apps: [App!]!
     app(appId: String!): App
+    domains(appId: String!): Domains!
     database(databaseId: String!): Database
     databases: [Database!]!
     isPluginInstalled(pluginName: String!): IsPluginInstalledResult!
@@ -232,6 +264,9 @@ const typeDefs = gql`
 
   type Mutation {
     loginWithGithub(code: String!): LoginResult
+    addDomain(input: AddDomainInput!): AddDomainResult!
+    removeDomain(input: RemoveDomainInput!): RemoveDomainResult!
+    setDomain(input: SetDomainInput!): SetDomainResult!
     createApp(input: CreateAppInput!): CreateAppResult!
     createDatabase(input: CreateDatabaseInput!): CreateDatabaseResult!
     setEnvVar(input: SetEnvVarInput!): SetEnvVarResult!

--- a/server/src/lib/dokku/domains/add.ts
+++ b/server/src/lib/dokku/domains/add.ts
@@ -1,0 +1,11 @@
+import { NodeSSH } from 'node-ssh';
+
+export const add = async (ssh: NodeSSH, name: string, domainName: string) => {
+  const resultAddDomain = await ssh.execCommand(
+    `domains:add ${name} ${domainName}`
+  );
+
+  if (resultAddDomain.code === 1) {
+    throw new Error(resultAddDomain.stderr);
+  }
+};

--- a/server/src/lib/dokku/domains/remove.ts
+++ b/server/src/lib/dokku/domains/remove.ts
@@ -1,0 +1,15 @@
+import { NodeSSH } from 'node-ssh';
+
+export const remove = async (
+  ssh: NodeSSH,
+  name: string,
+  domainName: string
+) => {
+  const resultRemoveDomain = await ssh.execCommand(
+    `domains:remove ${name} ${domainName}`
+  );
+
+  if (resultRemoveDomain.code === 1) {
+    throw new Error(resultRemoveDomain.stderr);
+  }
+};

--- a/server/src/lib/dokku/domains/report.ts
+++ b/server/src/lib/dokku/domains/report.ts
@@ -1,0 +1,18 @@
+import { NodeSSH } from 'node-ssh';
+
+const parseDomainsCommand = (commandResult: string) => {
+  const domains = commandResult.split(' ');
+  return domains;
+};
+
+export const report = async (ssh: NodeSSH, name: string) => {
+  const resultReportDomains = await ssh.execCommand(
+    `domains:report ${name} --domains-app-vhosts`
+  );
+
+  if (resultReportDomains.code === 1) {
+    throw new Error(resultReportDomains.stderr);
+  }
+
+  return parseDomainsCommand(resultReportDomains.stdout);
+};

--- a/server/src/lib/dokku/domains/set.ts
+++ b/server/src/lib/dokku/domains/set.ts
@@ -1,0 +1,11 @@
+import { NodeSSH } from 'node-ssh';
+
+export const set = async (ssh: NodeSSH, name: string, domainName: string) => {
+  const resultSetDomain = await ssh.execCommand(
+    `domains:set ${name} ${domainName}`
+  );
+
+  if (resultSetDomain.code === 1) {
+    throw new Error(resultSetDomain.stderr);
+  }
+};

--- a/server/src/lib/dokku/index.ts
+++ b/server/src/lib/dokku/index.ts
@@ -19,6 +19,10 @@ import { proxyPorts } from './proxy/ports';
 import { proxyPortsAdd } from './proxy/portsAdd';
 import { proxyPortsRemove } from './proxy/portsRemove';
 import { restart } from './process/restart';
+import { report } from './domains/report';
+import { set as domainsSet } from './domains/set';
+import { remove } from './domains/remove';
+import { add } from './domains/add';
 
 export const dokku = {
   apps: { create, logs, destroy, list: appList },
@@ -41,5 +45,11 @@ export const dokku = {
   },
   process: {
     restart,
+  },
+  domains: {
+    report,
+    set: domainsSet,
+    remove,
+    add,
   },
 };


### PR DESCRIPTION
closes : https://github.com/ledokku/ledokku/issues/198

`setDomain` -> overwrites the domain list with the domain that is provided to fn
`addDomaiun` -> adds domain to the list of existing domains

I left both of methods in as I suspect we might need to use this later, but for now only add is used. 

Screenshot of new looks below. 

![image](https://user-images.githubusercontent.com/25903618/100548484-85a9eb00-3275-11eb-973a-6e2a3ac15d8f.png)
