### PR TITLE
fix: force `DOKKU_SSH_HOST` to ipv4 during installation

### DIFF
--- a/ledokku-bootstrap.sh
+++ b/ledokku-bootstrap.sh
@@ -40,7 +40,7 @@ main() {
   LEDOKKU_TAG=${LEDOKKU_TAG:-"0.5.1"}
 
   # First we get the user ip so we can use it in the text we print later
-  DOKKU_SSH_HOST=$(curl ifconfig.co)
+  DOKKU_SSH_HOST=$(curl -4 ifconfig.co)
 
   echo "=== 🐳 ledokku:${LEDOKKU_TAG} ==="
   echo "Welcome to installation helper of Ledokku"


### PR DESCRIPTION
From https://ifconfig.co/:
> How do I force IPv4 or IPv6 lookup?
As of 2018-07-25 it's no longer possible to force protocol using the v4 and v6 subdomains. IPv4 or IPv6 still can be forced by passing the appropiate flag to your client, e.g curl -4 or curl -6.