### PR TITLE
docs: update uninstall.md

### DIFF
--- a/website/docs/uninstall.md
+++ b/website/docs/uninstall.md
@@ -12,6 +12,8 @@ delete all of the associated data, run these commands on your server:
 dokku apps:destroy ledokku
 dokku postgres:destroy ledokku
 dokku redis:destroy ledokku
+rm -rf /var/lib/dokku/data/storage/ledokku-ssh
+rm -rf /home/dokku/ledokku
 ```
 
 # Remove both Ledokku and dokku


### PR DESCRIPTION
Additional work is needed to completely remove ledokku (and allow reinstalling it, if desired).  Without removing those additional files and directories, the install script will fail if reinstalling.