### PR TITLE
SSH is not Web

### DIFF
--- a/server/src/config.ts
+++ b/server/src/config.ts
@@ -14,6 +14,9 @@ const envSchema = yup.object({
   DOKKU_SSH_HOST: yup
     .string()
     .required('Please provide a valid DOKKU_SSH_HOST env variable.'),
+  DOKKU_WEB_HOST: yup
+    .string()
+    .required('Please provide a valid DOKKU_WEB_HOST env variable.').stripEmptyString().default(process.env.DOKKU_SSH_HOST),
   DOKKU_SSH_PORT: yup.string(),
   /**
    * Temporary solution until we have proper user management.
@@ -108,6 +111,7 @@ export const config = {
   githubAppPem: formatGithubPem(process.env.GITHUB_APP_PEM),
   redisUrl: process.env.REDIS_URL,
   dokkuSshHost: process.env.DOKKU_SSH_HOST,
+  dokkuWebHost: process.env.DOKKU_WEB_HOST,
   dokkuSshPort: process.env.DOKKU_SSH_PORT ? +process.env.DOKKU_SSH_PORT : 22,
   privateKey,
   sshKeyPath,

--- a/server/src/config.ts
+++ b/server/src/config.ts
@@ -16,7 +16,7 @@ const envSchema = yup.object({
     .required('Please provide a valid DOKKU_SSH_HOST env variable.'),
   DOKKU_WEB_HOST: yup
     .string()
-    .required('Please provide a valid DOKKU_WEB_HOST env variable.').stripEmptyString().default(process.env.DOKKU_SSH_HOST),
+    .required('Please provide a valid DOKKU_WEB_HOST env variable.'),
   DOKKU_SSH_PORT: yup.string(),
   /**
    * Temporary solution until we have proper user management.

--- a/server/src/graphql/queries/setup.ts
+++ b/server/src/graphql/queries/setup.ts
@@ -30,22 +30,22 @@ export const setup: QueryResolvers['setup'] = async () => {
       name: 'Ledokku',
       url:
         process.env.NODE_ENV === 'production'
-          ? `http://${config.dokkuSshHost}`
+          ? `http://${config.dokkuWebHost}`
           : 'http://localhost:3000',
       request_oauth_on_install: true,
       callback_url:
         process.env.NODE_ENV === 'production'
-          ? `http://${config.dokkuSshHost}`
+          ? `http://${config.dokkuWebHost}`
           : 'http://localhost:3000',
       hook_attributes: {
         url:
           process.env.NODE_ENV === 'production'
-            ? `http://${config.dokkuSshHost}/github/api/webhooks`
+            ? `http://${config.dokkuWebHost}/github/api/webhooks`
             : config.webhookProxyUrl,
       },
       redirect_url:
         process.env.NODE_ENV === 'production'
-          ? `http://${config.dokkuSshHost}`
+          ? `http://${config.dokkuWebHost}`
           : 'http://localhost:3000',
       public: false,
       default_permissions: {


### PR DESCRIPTION
In the interest of keeping separate things separate, I'd like to be able to specify the webhost for callbacks separately from the ssh host for controlling dokku.

This PR sort of does this. Forgive me: javascript is not a language I am all that familiar with.